### PR TITLE
fix loadContract when provider is chainId 1337

### DIFF
--- a/packages/react-app/src/views/Homepage.jsx
+++ b/packages/react-app/src/views/Homepage.jsx
@@ -82,7 +82,13 @@ function Homepage({
   };
 
   const loadContract = async (type, address = null) => {
-    if (selectedChainId && selectedNetwork.chainId !== selectedChainId) {
+    // Make sure network is the same in selection and provider
+    if (
+      selectedChainId &&
+      selectedNetwork.chainId !== selectedChainId &&
+      // Ignore case when provider chain is 1337 instead of 31337
+      !(selectedNetwork.chainId === 31337 && selectedChainId === 1337)
+    ) {
       message.error(`Please switch your wallet to ${selectedNetwork.name}.`);
       return;
     }


### PR DESCRIPTION
Currently if you are connected with your provider (lets assume Metamask) and you are using localhost and your localhost chainId is 1337 then you can't load a contract until you disconnect your provider. 

This fixes that behavior by adding a condition where it returns false if your selectedNetwork is localhost and your  injected provider chainId is 1337 instead of the expected 31337.