### PR TITLE
Update blockexplorer styles

### DIFF
--- a/packages/nextjs/components/MiniHeader.tsx
+++ b/packages/nextjs/components/MiniHeader.tsx
@@ -4,7 +4,7 @@ import { RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
 
 export const MiniHeader = () => {
   return (
-    <div className="sticky lg:static top-0 navbar bg-white min-h-0 flex-shrink-0 justify-between z-20 px-0 sm:px-2 mb-10">
+    <div className="sticky lg:static top-0 navbar bg-white border-b border-secondary min-h-0 flex-shrink-0 justify-between z-20 px-0 sm:px-2 mb-10">
       <div className="navbar-start w-auto lg:w-1/2">
         <Link href="/" passHref className="hidden sm:flex items-center gap-2 ml-4 mr-6 shrink-0">
           <div className="flex items-center">

--- a/packages/nextjs/components/blockexplorer/SearchBar.tsx
+++ b/packages/nextjs/components/blockexplorer/SearchBar.tsx
@@ -33,7 +33,7 @@ export const SearchBar = () => {
   return (
     <form onSubmit={handleSearch} className="flex items-center justify-end mb-5 space-x-3 mx-5">
       <input
-        className="border-primary bg-base-100 text-base-content p-2 mr-2 w-full md:w-1/2 lg:w-1/3 rounded-md shadow-md focus:outline-none focus:ring-2 focus:ring-accent"
+        className="border-primary bg-base-100 text-base-content p-2 mr-2 w-full md:w-1/2 lg:w-1/3 rounded-md shadow-md focus:outline-none focus:ring-2 focus:ring-secondary"
         type="text"
         value={searchInput}
         placeholder="Search by hash or address"

--- a/packages/nextjs/components/blockexplorer/TransactionsTable.tsx
+++ b/packages/nextjs/components/blockexplorer/TransactionsTable.tsx
@@ -13,7 +13,7 @@ export const TransactionsTable = ({ blocks, transactionReceipts }: TransactionsT
       <div className="overflow-x-auto w-full shadow-2xl rounded-xl">
         <table className="table text-xl bg-base-100 table-zebra w-full md:table-md table-sm">
           <thead>
-            <tr className="rounded-xl text-sm text-base-content">
+            <tr className="rounded-xl text-sm text-white">
               <th className="bg-primary">Transaction Hash</th>
               <th className="bg-primary">Function Called</th>
               <th className="bg-primary">Block Number</th>

--- a/packages/nextjs/pages/blockexplorer/address/[address].tsx
+++ b/packages/nextjs/pages/blockexplorer/address/[address].tsx
@@ -1,5 +1,7 @@
 import { useRouter } from "next/router";
 import { Address as AddressType } from "viem";
+import { MetaHeader } from "~~/components/MetaHeader";
+import { MiniHeader } from "~~/components/MiniHeader";
 import { PaginationButton, TransactionsTable } from "~~/components/blockexplorer/";
 import { Address, Balance } from "~~/components/scaffold-eth";
 import { useFetchBlocks } from "~~/hooks/scaffold-eth";
@@ -19,32 +21,40 @@ const AddressPage = () => {
   );
 
   return (
-    <div className="m-10 mb-20">
-      <div className="flex justify-start mb-5">
-        <button className="btn btn-sm btn-primary" onClick={() => router.back()}>
-          Back
-        </button>
-      </div>
-      <div className="col-span-5 grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-10">
-        <div className="col-span-1 flex flex-col">
-          <div className="bg-base-100 border-base-300 border shadow-md shadow-secondary rounded-3xl px-6 lg:px-8 mb-6 space-y-1 py-4 overflow-x-auto">
-            <div className="flex">
-              <div className="flex flex-col gap-1">
-                <Address address={address} format="long" />
-                <div className="flex gap-1 items-center">
-                  <span className="font-bold text-sm">Balance:</span>
-                  <Balance address={address} className="text" />
+    <>
+      <MetaHeader title="Block explorer - Address details" />
+      <MiniHeader />
+      <div className="mx-10 mb-20">
+        <div className="flex justify-start mb-5">
+          <button className="btn btn-sm btn-primary" onClick={() => router.back()}>
+            Back
+          </button>
+        </div>
+        <div className="col-span-5 grid grid-cols-1 lg:grid-cols-2 gap-8 lg:gap-10">
+          <div className="col-span-1 flex flex-col">
+            <div className="bg-base-100 border-base-300 border shadow-md shadow-secondary rounded-3xl px-6 lg:px-8 mb-6 space-y-1 py-4 overflow-x-auto">
+              <div className="flex">
+                <div className="flex flex-col gap-1">
+                  <Address address={address} format="long" />
+                  <div className="flex gap-1 items-center">
+                    <span className="font-bold text-sm">Balance:</span>
+                    <Balance address={address} className="text" />
+                  </div>
                 </div>
               </div>
             </div>
           </div>
         </div>
+        <div className="pt-4">
+          <TransactionsTable blocks={filteredBlocks} transactionReceipts={transactionReceipts} />
+          <PaginationButton
+            currentPage={currentPage}
+            totalItems={Number(totalBlocks)}
+            setCurrentPage={setCurrentPage}
+          />
+        </div>
       </div>
-      <div className="pt-4">
-        <TransactionsTable blocks={filteredBlocks} transactionReceipts={transactionReceipts} />
-        <PaginationButton currentPage={currentPage} totalItems={Number(totalBlocks)} setCurrentPage={setCurrentPage} />
-      </div>
-    </div>
+    </>
   );
 };
 

--- a/packages/nextjs/pages/blockexplorer/index.tsx
+++ b/packages/nextjs/pages/blockexplorer/index.tsx
@@ -1,6 +1,8 @@
 import { useEffect } from "react";
 import type { NextPage } from "next";
 import { hardhat } from "viem/chains";
+import { MetaHeader } from "~~/components/MetaHeader";
+import { MiniHeader } from "~~/components/MiniHeader";
 import { PaginationButton } from "~~/components/blockexplorer/PaginationButton";
 import { SearchBar } from "~~/components/blockexplorer/SearchBar";
 import { TransactionsTable } from "~~/components/blockexplorer/TransactionsTable";
@@ -51,11 +53,15 @@ const Blockexplorer: NextPage = () => {
   }, [error, targetNetwork]);
 
   return (
-    <div className="container mx-auto my-10">
-      <SearchBar />
-      <TransactionsTable blocks={blocks} transactionReceipts={transactionReceipts} />
-      <PaginationButton currentPage={currentPage} totalItems={Number(totalBlocks)} setCurrentPage={setCurrentPage} />
-    </div>
+    <>
+      <MetaHeader title="Block Explorer" />
+      <MiniHeader />
+      <div className="container mx-auto">
+        <SearchBar />
+        <TransactionsTable blocks={blocks} transactionReceipts={transactionReceipts} />
+        <PaginationButton currentPage={currentPage} totalItems={Number(totalBlocks)} setCurrentPage={setCurrentPage} />
+      </div>
+    </>
   );
 };
 

--- a/packages/nextjs/pages/blockexplorer/transaction/[txHash].tsx
+++ b/packages/nextjs/pages/blockexplorer/transaction/[txHash].tsx
@@ -4,6 +4,8 @@ import type { NextPage } from "next";
 import { Hash, Transaction, TransactionReceipt, formatEther, formatUnits } from "viem";
 import { hardhat } from "viem/chains";
 import { usePublicClient } from "wagmi";
+import { MetaHeader } from "~~/components/MetaHeader";
+import { MiniHeader } from "~~/components/MiniHeader";
 import { Address } from "~~/components/scaffold-eth";
 import { useTargetNetwork } from "~~/hooks/scaffold-eth/useTargetNetwork";
 import { decodeTransactionData, getFunctionDetails } from "~~/utils/scaffold-eth";
@@ -39,110 +41,118 @@ const TransactionPage: NextPage = () => {
   }, [client, txHash]);
 
   return (
-    <div className="container mx-auto mt-10 mb-20 px-10 md:px-0">
-      <button className="btn btn-sm btn-primary" onClick={() => router.back()}>
-        Back
-      </button>
-      {transaction ? (
-        <div className="overflow-x-auto">
-          <h2 className="text-3xl font-bold mb-4 text-center text-primary-content">Transaction Details</h2>{" "}
-          <table className="table rounded-lg bg-base-100 w-full shadow-lg md:table-lg table-md">
-            <tbody>
-              <tr>
-                <td>
-                  <strong>Transaction Hash:</strong>
-                </td>
-                <td>{transaction.hash}</td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>Block Number:</strong>
-                </td>
-                <td>{Number(transaction.blockNumber)}</td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>From:</strong>
-                </td>
-                <td>
-                  <Address address={transaction.from} format="long" />
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>To:</strong>
-                </td>
-                <td>
-                  {!receipt?.contractAddress ? (
-                    transaction.to && <Address address={transaction.to} format="long" />
-                  ) : (
-                    <span>
-                      Contract Creation:
-                      <Address address={receipt.contractAddress} format="long" />
-                    </span>
-                  )}
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>Value:</strong>
-                </td>
-                <td>
-                  {formatEther(transaction.value)} {targetNetwork.nativeCurrency.symbol}
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>Function called:</strong>
-                </td>
-                <td>
-                  <div className="w-full md:max-w-[600px] lg:max-w-[800px] overflow-x-auto whitespace-nowrap">
-                    {functionCalled === "0x" ? (
-                      "This transaction did not call any function."
+    <>
+      <MetaHeader title="Block explorer - Transaction details" />
+      <MiniHeader />
+      <div className="container mx-auto mb-20 px-10 md:px-0">
+        <button className="btn btn-sm btn-primary" onClick={() => router.back()}>
+          Back
+        </button>
+        {transaction ? (
+          <div className="overflow-x-auto">
+            <h2 className="text-3xl font-bold mb-4 text-center text-primary-content">Transaction Details</h2>{" "}
+            <table className="table rounded-lg bg-base-100 w-full shadow-lg md:table-lg table-md">
+              <tbody>
+                <tr>
+                  <td>
+                    <strong>Transaction Hash:</strong>
+                  </td>
+                  <td>{transaction.hash}</td>
+                </tr>
+                <tr>
+                  <td>
+                    <strong>Block Number:</strong>
+                  </td>
+                  <td>{Number(transaction.blockNumber)}</td>
+                </tr>
+                <tr>
+                  <td>
+                    <strong>From:</strong>
+                  </td>
+                  <td>
+                    <Address address={transaction.from} format="long" />
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <strong>To:</strong>
+                  </td>
+                  <td>
+                    {!receipt?.contractAddress ? (
+                      transaction.to && <Address address={transaction.to} format="long" />
                     ) : (
-                      <>
-                        <span className="mr-2">{getFunctionDetails(transaction)}</span>
-                        <span className="badge badge-primary font-bold">{functionCalled}</span>
-                      </>
+                      <span>
+                        Contract Creation:
+                        <Address address={receipt.contractAddress} format="long" />
+                      </span>
                     )}
-                  </div>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>Gas Price:</strong>
-                </td>
-                <td>{formatUnits(transaction.gasPrice || 0n, 9)} Gwei</td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>Data:</strong>
-                </td>
-                <td className="form-control">
-                  <textarea readOnly value={transaction.input} className="p-0 textarea-primary bg-inherit h-[150px]" />
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <strong>Logs:</strong>
-                </td>
-                <td>
-                  <ul>
-                    {receipt?.logs?.map((log, i) => (
-                      <li key={i}>
-                        <strong>Log {i} topics:</strong> {JSON.stringify(log.topics, replacer, 2)}
-                      </li>
-                    ))}
-                  </ul>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-        </div>
-      ) : (
-        <p className="text-2xl text-base-content">Loading...</p>
-      )}
-    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <strong>Value:</strong>
+                  </td>
+                  <td>
+                    {formatEther(transaction.value)} {targetNetwork.nativeCurrency.symbol}
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <strong>Function called:</strong>
+                  </td>
+                  <td>
+                    <div className="w-full md:max-w-[600px] lg:max-w-[800px] overflow-x-auto whitespace-nowrap">
+                      {functionCalled === "0x" ? (
+                        "This transaction did not call any function."
+                      ) : (
+                        <>
+                          <span className="mr-2">{getFunctionDetails(transaction)}</span>
+                          <span className="badge badge-primary font-bold">{functionCalled}</span>
+                        </>
+                      )}
+                    </div>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <strong>Gas Price:</strong>
+                  </td>
+                  <td>{formatUnits(transaction.gasPrice || 0n, 9)} Gwei</td>
+                </tr>
+                <tr>
+                  <td>
+                    <strong>Data:</strong>
+                  </td>
+                  <td className="form-control">
+                    <textarea
+                      readOnly
+                      value={transaction.input}
+                      className="p-0 textarea-primary bg-inherit h-[150px]"
+                    />
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    <strong>Logs:</strong>
+                  </td>
+                  <td>
+                    <ul>
+                      {receipt?.logs?.map((log, i) => (
+                        <li key={i}>
+                          <strong>Log {i} topics:</strong> {JSON.stringify(log.topics, replacer, 2)}
+                        </li>
+                      ))}
+                    </ul>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        ) : (
+          <p className="text-2xl text-base-content">Loading...</p>
+        )}
+      </div>
+    </>
   );
 };
 


### PR DESCRIPTION
Adding a few style tweaks to the blockexplorer feature we've added for localhost.

Main changes:

- Added `<MetaHeader>` with basic title to the blockexplorer pages.
- Added  `<MiniHeader>` with small tweaks for white background pages.
- Small color tweaks to improve readability and be more consistent.

Closes #33 