### PR TITLE
Fetch abi from AnyABI as first source and leave Etherscan as fallback

### DIFF
--- a/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
+++ b/packages/nextjs/components/scaffold-eth/RainbowKitCustomConnectButton/index.tsx
@@ -15,7 +15,6 @@ import { getBlockExplorerAddressLink } from "~~/utils/scaffold-eth";
 export const RainbowKitCustomConnectButton = () => {
   useAutoConnect();
   const mainChainId = useAbiNinjaState(state => state.mainChainId);
-  console.log("mainChainId: ", mainChainId);
   const networkColor = useNetworkColor();
   const { targetNetwork } = useTargetNetwork();
 

--- a/packages/nextjs/pages/[contractAddress]/[network].tsx
+++ b/packages/nextjs/pages/[contractAddress]/[network].tsx
@@ -10,7 +10,7 @@ import { MetaHeader } from "~~/components/MetaHeader";
 import { MiniHeader } from "~~/components/MiniHeader";
 import { ContractUI } from "~~/components/scaffold-eth";
 import { useAbiNinjaState } from "~~/services/store/store";
-import { fetchContractABIFromEtherscan } from "~~/utils/abi";
+import { fetchContractABIFromAnyABI, fetchContractABIFromEtherscan } from "~~/utils/abi";
 
 interface ParsedQueryContractDetailsPage extends ParsedUrlQuery {
   contractAddress: string;
@@ -53,9 +53,14 @@ const ContractDetailPage = () => {
         if (storedAbi && storedAbi.length > 0) {
           setContractData({ abi: storedAbi, address: contractAddress });
         } else {
-          const abiString = await fetchContractABIFromEtherscan(contractAddress, parseInt(network));
-          const abi = JSON.parse(abiString);
-          setContractData({ abi, address: contractAddress });
+          const abi = await fetchContractABIFromAnyABI(contractAddress, parseInt(network));
+          if (abi) {
+            setContractData({ abi, address: contractAddress });
+          } else {
+            const abiString = await fetchContractABIFromEtherscan(contractAddress, parseInt(network));
+            const abi = JSON.parse(abiString);
+            setContractData({ abi, address: contractAddress });
+          }
         }
         setError(null);
       } catch (e: any) {

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -25,7 +25,6 @@ const Home: NextPage = () => {
   const [activeTab, setActiveTab] = useState(TabName.verifiedContract);
   const [network, setNetwork] = useState(networks[1].id.toString());
   const [verifiedContractAddress, setVerifiedContractAddress] = useState<Address>("");
-  const [verifiedContractInput, setVerifiedContractInput] = useState("");
   const [localAbiContractAddress, setLocalAbiContractAddress] = useState("");
   const [localContractAbi, setLocalContractAbi] = useState("");
   const [isFetchingAbi, setIsFetchingAbi] = useState(false);
@@ -77,6 +76,8 @@ const Home: NextPage = () => {
         return;
       }
       fetchContractAbi();
+    } else {
+      setIsAbiAvailable(false);
     }
   }, [verifiedContractAddress, network, setContractAbi]);
 
@@ -127,15 +128,6 @@ const Home: NextPage = () => {
       }
       setAbiContractAddress(localAbiContractAddress);
       router.push(`/${localAbiContractAddress}/${network}`);
-    }
-  };
-
-  const handleVerifiedContractInput = (input: string) => {
-    setVerifiedContractInput(input);
-    if (isAddress(input)) {
-      setVerifiedContractAddress(input);
-    } else {
-      setVerifiedContractAddress("");
     }
   };
 
@@ -203,9 +195,9 @@ const Home: NextPage = () => {
                     {tabValue === TabName.verifiedContract ? (
                       <div className="my-4">
                         <AddressInput
-                          value={verifiedContractInput}
+                          value={verifiedContractAddress}
                           placeholder="Verified contract address"
-                          onChange={handleVerifiedContractInput}
+                          onChange={setVerifiedContractAddress}
                         />
                         <div className="flex flex-col text-sm">
                           <div className="mb-2 mt-4 text-center font-semibold">Quick Access</div>

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -55,7 +55,7 @@ const Home: NextPage = () => {
         setIsAbiAvailable(true);
       } catch (error) {
         console.error("Error fetching ABI from AnyABI: ", error);
-        console.log("Trying to ABI fetch from Etherscan...");
+        console.log("Trying to fetch ABI from Etherscan...");
         try {
           const abiString = await fetchContractABIFromEtherscan(verifiedContractAddress, parseInt(network));
           const abi = JSON.parse(abiString);

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -9,7 +9,7 @@ import { MetaHeader } from "~~/components/MetaHeader";
 import { MiniFooter } from "~~/components/MiniFooter";
 import { AddressInput, InputBase } from "~~/components/scaffold-eth";
 import { useAbiNinjaState } from "~~/services/store/store";
-import { fetchContractABIFromEtherscan, parseAndCorrectJSON } from "~~/utils/abi";
+import { fetchContractABIFromAnyABI, fetchContractABIFromEtherscan, parseAndCorrectJSON } from "~~/utils/abi";
 import { getTargetNetworks, notification } from "~~/utils/scaffold-eth";
 
 enum TabName {
@@ -49,8 +49,16 @@ const Home: NextPage = () => {
     const fetchContractAbi = async () => {
       setIsFetchingAbi(true);
       try {
-        await fetchContractABIFromEtherscan(verifiedContractAddress, parseInt(network));
-        setIsAbiAvailable(true);
+        const abi = await fetchContractABIFromAnyABI(verifiedContractAddress, parseInt(network));
+        if (abi) {
+          setContractAbi(abi);
+          setIsAbiAvailable(true);
+        } else {
+          const abiString = await fetchContractABIFromEtherscan(verifiedContractAddress, parseInt(network));
+          const abi = JSON.parse(abiString);
+          setContractAbi(abi);
+          setIsAbiAvailable(true);
+        }
       } catch (e: any) {
         setIsAbiAvailable(false);
         if (e.message) {

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -78,7 +78,7 @@ const Home: NextPage = () => {
       }
       fetchContractAbi();
     }
-  }, [verifiedContractAddress, network]);
+  }, [verifiedContractAddress, network, setContractAbi]);
 
   useEffect(() => {
     const checkContract = async () => {

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -50,22 +50,22 @@ const Home: NextPage = () => {
       setIsFetchingAbi(true);
       try {
         const abi = await fetchContractABIFromAnyABI(verifiedContractAddress, parseInt(network));
-        if (abi) {
-          setContractAbi(abi);
-          setIsAbiAvailable(true);
-        } else {
+        if (!abi) throw new Error("Got empty or undefined ABI from AnyABI");
+        setContractAbi(abi);
+        setIsAbiAvailable(true);
+      } catch (error) {
+        console.error("Error fetching ABI from AnyABI: ", error);
+        console.log("Trying to ABI fetch from Etherscan...");
+        try {
           const abiString = await fetchContractABIFromEtherscan(verifiedContractAddress, parseInt(network));
           const abi = JSON.parse(abiString);
           setContractAbi(abi);
           setIsAbiAvailable(true);
+        } catch (etherscanError: any) {
+          setIsAbiAvailable(false);
+          console.error("Error fetching ABI from Etherscan: ", etherscanError);
+          notification.error(etherscanError.message || "Error occurred while fetching ABI");
         }
-      } catch (e: any) {
-        setIsAbiAvailable(false);
-        if (e.message) {
-          notification.error(e.message);
-          return;
-        }
-        notification.error("Error occured while fetching abi");
       } finally {
         setIsFetchingAbi(false);
       }

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -25,6 +25,7 @@ const Home: NextPage = () => {
   const [activeTab, setActiveTab] = useState(TabName.verifiedContract);
   const [network, setNetwork] = useState(networks[1].id.toString());
   const [verifiedContractAddress, setVerifiedContractAddress] = useState<Address>("");
+  const [verifiedContractInput, setVerifiedContractInput] = useState("");
   const [localAbiContractAddress, setLocalAbiContractAddress] = useState("");
   const [localContractAbi, setLocalContractAbi] = useState("");
   const [isFetchingAbi, setIsFetchingAbi] = useState(false);
@@ -121,6 +122,15 @@ const Home: NextPage = () => {
     }
   };
 
+  const handleVerifiedContractInput = (input: string) => {
+    setVerifiedContractInput(input);
+    if (isAddress(input)) {
+      setVerifiedContractAddress(input);
+    } else {
+      setVerifiedContractAddress("");
+    }
+  };
+
   return (
     <>
       <MetaHeader />
@@ -185,9 +195,9 @@ const Home: NextPage = () => {
                     {tabValue === TabName.verifiedContract ? (
                       <div className="my-4">
                         <AddressInput
-                          value={verifiedContractAddress}
+                          value={verifiedContractInput}
                           placeholder="Verified contract address"
-                          onChange={setVerifiedContractAddress}
+                          onChange={handleVerifiedContractInput}
                         />
                         <div className="flex flex-col text-sm">
                           <div className="mb-2 mt-4 text-center font-semibold">Quick Access</div>
@@ -239,7 +249,7 @@ const Home: NextPage = () => {
               className="btn btn-primary px-8 text-base border-2 hover:bg-white hover:text-primary"
               onClick={handleLoadContract}
               disabled={
-                (activeTab === TabName.verifiedContract && !isAbiAvailable) ||
+                (activeTab === TabName.verifiedContract && (!isAbiAvailable || !verifiedContractAddress)) ||
                 (activeTab === TabName.addressAbi &&
                   (!isContract || !localContractAbi || localContractAbi.length === 0))
               }

--- a/packages/nextjs/utils/abi.ts
+++ b/packages/nextjs/utils/abi.ts
@@ -1,5 +1,22 @@
 import { NETWORKS_EXTRA_DATA } from "./scaffold-eth";
 
+export const fetchContractABIFromAnyABI = async (verifiedContractAddress: string, chainId: number) => {
+  const chain = NETWORKS_EXTRA_DATA[chainId];
+
+  if (!chain) throw new Error(`ChainId ${chainId} not found in supported networks`);
+
+  const url = `https://anyabi.xyz/api/get-abi/${chainId}/${verifiedContractAddress}`;
+
+  const response = await fetch(url);
+  const data = await response.json();
+  if (data.abi) {
+    return data.abi;
+  } else {
+    console.error("Could not fetch ABI from AnyABI:", data.error);
+    return;
+  }
+};
+
 export const fetchContractABIFromEtherscan = async (verifiedContractAddress: string, chainId: number) => {
   const chain = NETWORKS_EXTRA_DATA[chainId];
 


### PR DESCRIPTION
Working on this draft to fetch abi from AnyABI API, to not have to deal with Etherscan API limits. 

Current Etherscan abi fetch stays as fallback option in case AnyABI fails to fetch the abi.

- [x] Create function to fetch abi from AnyABI 
- [x] Set fetchContractABIFromAnyABI as first option in ContractDetailPage
- [x] Set fetchContractABIFromAnyABI as first option in Homepage

In https://github.com/BuidlGuidl/abi.ninja/pull/35/commits/c8b4af94e84f398ee21c647cdde43358fb4e7504 I've also added the abi load into the global state. The reasoning behind it was that we were already fetching Etherscan API to know if the abi was available, so with that change we save a fetch in ContractDetailPage, but probably duplicating the code in both pages isn't the way to go, let me know what do you think 🙌

Closes #26 