### PR TITLE
Fix wrong footer position on some resolutions

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
@@ -106,14 +106,14 @@ export const ContractUI = ({ className = "", initialContractData }: ContractUIPr
       <input id="sidebar" type="checkbox" className="drawer-toggle" />
       <div className="drawer-side h-full z-50">
         <label htmlFor="sidebar" aria-label="close sidebar" className="drawer-overlay"></label>
-        <ul className="menu p-6 pr-0 bg-white h-full justify-between">
+        <ul className="menu p-6 pr-0 pb-3 bg-white h-full justify-between flex-nowrap">
           <MethodSelector
             readMethodsWithInputsAndWriteMethods={readMethodsWithInputsAndWriteMethods}
             abi={abi}
             onMethodSelect={handleMethodSelect}
             removeMethod={removeMethod}
           />
-          <div className="flex justify-center items-center gap-1 text-xs w-full pr-6">
+          <div className="flex justify-center items-center gap-1 text-xs w-full pr-6 pt-4">
             <div className="mb-1">
               <a href="https://github.com/scaffold-eth/se-2" target="_blank" rel="noreferrer" className="link">
                 Fork me


### PR DESCRIPTION
The «footer» was appearing in a weird position on some resolutions. It was because the `menu` class has flex wrap on. Hope I'm not breaking anything :D


Before:
![1](https://github.com/BuidlGuidl/abi.ninja/assets/2486142/9ac1692c-2b37-4b31-8841-136a253772e1)

After:
![2](https://github.com/BuidlGuidl/abi.ninja/assets/2486142/966738a7-7f0d-4945-82fe-1197ad47398a)
