### PR TITLE
Fix read button placement and lower weight of empty methods messages

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Contract/ContractReadMethods.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractReadMethods.tsx
@@ -31,7 +31,7 @@ export const ContractReadMethods = ({
     .sort((a, b) => (b.inheritedFrom ? b.inheritedFrom.localeCompare(a.inheritedFrom) : 1));
 
   if (!functionsToDisplay.length) {
-    return <>Please select read methods from the sidebar.</>;
+    return <span className="font-light text-gray-500">Please select read methods from the sidebar.</span>;
   }
 
   return (

--- a/packages/nextjs/components/scaffold-eth/Contract/ContractWriteMethods.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractWriteMethods.tsx
@@ -32,10 +32,8 @@ export const ContractWriteMethods = ({
     .sort((a, b) => (b.inheritedFrom ? b.inheritedFrom.localeCompare(a.inheritedFrom) : 1));
 
   if (!functionsToDisplay.length) {
-    return <>Please select write methods from the sidebar.</>;
+    return <span className="font-light text-gray-500">Please select write methods from the sidebar.</span>;
   }
-
-  console.log("functionsToDisplay", functionsToDisplay);
 
   return (
     <>

--- a/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ReadOnlyFunctionForm.tsx
@@ -67,7 +67,7 @@ export const ReadOnlyFunctionForm = ({
         <InheritanceTooltip inheritedFrom={inheritedFrom} />
       </p>
       {inputElements}
-      <div className="flex justify-between gap-2 flex-wrap">
+      <div className="flex justify-end flex-wrap w-full">
         <div className="flex-grow w-4/5">
           {result !== null && result !== undefined && (
             <div className="bg-secondary rounded-3xl text-sm px-4 py-1.5 break-words">


### PR DESCRIPTION
A couple of small tweaks:

- #50 
- Feedback messages when there were no Read/Write methods selected was a bit too heavy.

Before: ![image](https://github.com/BuidlGuidl/abi.ninja/assets/55535804/c2e5524f-4e8e-4106-a640-c4dcbeb19198)
After: 
![image](https://github.com/BuidlGuidl/abi.ninja/assets/55535804/73ca4cc0-e6ee-4705-9c63-68b25a1fbc4c)

Read button after fix:
![read-button-fixed](https://github.com/BuidlGuidl/abi.ninja/assets/55535804/de2eb89a-6607-49bf-9e25-c24e76ee172e)
