### PR TITLE
Update contributing guide to adapt it for Abi Ninja

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -4,8 +4,8 @@ _Concise description of proposed changes, We recommend using screenshots and vid
 
 ## Additional Information
 
-- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
-- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)
+- [ ] I have read the [contributing docs](https://github.com/BuidlGuidl/abi.ninja/blob/main/CONTRIBUTING.md) (if this is your first contribution)
+- [ ] This is not a duplicate of any [existing pull request](https://github.com/BuidlGuidl/abi.ninja/pulls)
 
 ## Related Issues
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,14 +1,14 @@
-# Welcome to Abi Ninja Contributing Guide
+# Welcome to ABI Ninja Contributing Guide
 
-Thank you for investing your time in contributing to Abi Ninja!
+Thank you for investing your time in contributing to ABI Ninja!
 
 This guide aims to provide an overview of the contribution workflow to help us make the contribution process effective for everyone involved.
 
 ## About the Project
 
-Abi Ninja is a tool to interact with any contract on Ethereum, using the Contract address (if it's verified) or its ABI + Contract address.
+ABI Ninja is a tool to interact with any contract on Ethereum, using the Contract address (if it's verified) or its ABI + Contract address.
 
-Current version is built with [Scaffold-ETH 2](https://github.com/scaffold-eth/scaffold-eth-2).
+The current version is built with [Scaffold-ETH 2](https://github.com/scaffold-eth/scaffold-eth-2).
 
 Read the [README](README.md) to get an overview of the project.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,20 +1,16 @@
-# Welcome to Scaffold-ETH 2 Contributing Guide
+# Welcome to Abi Ninja Contributing Guide
 
-Thank you for investing your time in contributing to Scaffold-ETH 2!
+Thank you for investing your time in contributing to Abi Ninja!
 
 This guide aims to provide an overview of the contribution workflow to help us make the contribution process effective for everyone involved.
 
 ## About the Project
 
-Scaffold-ETH 2 is a minimal and forkable repo providing builders with a starter kit to build decentralized applications on Ethereum.
+Abi Ninja is a tool to interact with any contract on Ethereum, using the Contract address (if it's verified) or its ABI + Contract address.
+
+Current version is built with [Scaffold-ETH 2](https://github.com/scaffold-eth/scaffold-eth-2).
 
 Read the [README](README.md) to get an overview of the project.
-
-### Vision
-
-The goal of Scaffold-ETH 2 is to provide the primary building blocks for a decentralized application.
-
-The repo can be forked to include integrations and more features, but we want to keep the master branch simple and minimal.
 
 ### Project Status
 
@@ -44,7 +40,7 @@ Issues should be used to report problems, request a new feature, or discuss pote
 
 #### Solve an issue
 
-Scan through our [existing issues](https://github.com/scaffold-eth/scaffold-eth-2/issues) to find one that interests you.
+Scan through our [existing issues](https://github.com/BuidlGuidl/abi.ninja/issues) to find one that interests you.
 
 If a contributor is working on the issue, they will be assigned to the individual. If you find an issue to work on, you are welcome to assign it to yourself and open a PR with a fix for it.
 

--- a/README.md
+++ b/README.md
@@ -36,4 +36,4 @@ Visit your local instance of ABI Ninja at: `http://localhost:3000`.
 
 We welcome contributions to ABI Ninja!
 
-Please see [CONTRIBUTING.MD](https://github.com/BuidlGuidl/abi.ninja/blob/main/CONTRIBUTING.md) for more information and guidelines for contributing to Abi Ninja.
+Please see [CONTRIBUTING.MD](https://github.com/BuidlGuidl/abi.ninja/blob/main/CONTRIBUTING.md) for more information and guidelines for contributing to ABI Ninja.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Before you begin, you need to install the following tools:
 - [Git](https://git-scm.com/downloads)
 
 1. Clone this repo & install dependencies
+
 ```
 git clone https://github.com/BuidlGuidl/abi.ninja.git
 cd abi.ninja
@@ -24,6 +25,7 @@ yarn install
 ```
 
 2. Start the frontend
+
 ```
 yarn start
 ```
@@ -34,4 +36,4 @@ Visit your local instance of ABI Ninja at: `http://localhost:3000`.
 
 We welcome contributions to ABI Ninja!
 
-We follow the same approach as in Scaffold-ETH so please see [CONTRIBUTING.MD](https://github.com/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) for more information and guidelines.
+Please see [CONTRIBUTING.MD](https://github.com/BuidlGuidl/abi.ninja/blob/main/CONTRIBUTING.md) for more information and guidelines for contributing to Abi Ninja.


### PR DESCRIPTION
This PR aims to update the Scaffold-ETH references from the Contribution Guide to Abi Ninja, and update Readme contribution paragraph. 

Another approach would be to keep the Readme as it is right now (with the link to SE-2 Contribution Guide), and just delete CONTRIBUTING.MD from this repo. LMK if you just prefer this option 🙌

Closes #56 

