### PR TITLE
Add logic to parse network name from URL

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useMemo, useReducer, useState } from "react";
-import router from "next/router";
+import { useRouter } from "next/router";
 import { ContractReadMethods } from "./ContractReadMethods";
 import { ContractVariables } from "./ContractVariables";
 import { ContractWriteMethods } from "./ContractWriteMethods";
@@ -28,6 +28,8 @@ export const ContractUI = ({ className = "", initialContractData }: ContractUIPr
   const mainChainId = useAbiNinjaState(state => state.mainChainId);
   const mainNetwork = mainNetworks.find(network => network.id === mainChainId);
   const networkColor = useNetworkColor(mainNetwork);
+  const router = useRouter();
+  const { network } = router.query as { network?: string };
 
   const updateUrlWithSelectedMethods = (selectedMethods: string[]) => {
     const currentQuery = new URLSearchParams(window.location.search);
@@ -36,7 +38,7 @@ export const ContractUI = ({ className = "", initialContractData }: ContractUIPr
     } else {
       currentQuery.delete("methods");
     }
-    const newPath = `/${initialContractData.address}/${mainChainId}`;
+    const newPath = `/${initialContractData.address}/${network}`;
 
     router.push({ pathname: newPath, query: currentQuery.toString() }, undefined, { shallow: true });
   };
@@ -83,7 +85,7 @@ export const ContractUI = ({ className = "", initialContractData }: ContractUIPr
       method => method.type === "function" && "name" in method && selectedMethodNames.includes(method.name),
     ) as AbiFunction[]; // Cast it to AbiFunction[]
     setAbi(selectedMethods);
-  }, [initialContractData.abi]);
+  }, [initialContractData.abi, router?.query?.methods]);
 
   const { data: contractNameData, isLoading: isContractNameLoading } = useContractRead({
     address: initialContractData.address,

--- a/packages/nextjs/pages/[contractAddress]/[network].tsx
+++ b/packages/nextjs/pages/[contractAddress]/[network].tsx
@@ -27,12 +27,16 @@ const ContractDetailPage = () => {
   const { contractAddress, network } = router.query as ParsedQueryContractDetailsPage;
   const [contractData, setContractData] = useState<ContractData>({ abi: [], address: contractAddress });
   const [isLoading, setIsLoading] = useState(true);
-  const [chainId, setChainId] = useState<number>(1);
   const [error, setError] = useState<string | null>(null);
   const contractName = contractData.address;
-  const { contractAbi: storedAbi, setMainChainId } = useAbiNinjaState(state => ({
+  const {
+    contractAbi: storedAbi,
+    setMainChainId,
+    chainId,
+  } = useAbiNinjaState(state => ({
     contractAbi: state.contractAbi,
     setMainChainId: state.setMainChainId,
+    chainId: state.mainChainId,
   }));
 
   const getNetworkName = (chainId: number) => {
@@ -57,7 +61,6 @@ const ContractDetailPage = () => {
       }
 
       setMainChainId(parsedNetworkId);
-      setChainId(parsedNetworkId);
 
       const fetchContractAbi = async () => {
         setIsLoading(true);
@@ -76,7 +79,6 @@ const ContractDetailPage = () => {
           setError(null);
         } catch (error: any) {
           console.error("Error fetching ABI from AnyABI: ", error);
-          setError(error.message || "Error occurred while fetching ABI");
           console.log("Trying to fetch ABI from Etherscan...");
           try {
             const abiString = await fetchContractABIFromEtherscan(contractAddress, parsedNetworkId);


### PR DESCRIPTION
## Description

Currently users can manually set their url to open the ContractDetail page for their desired contract, by typing `/{contractAddress}/{chainId}` => for example gitcoin in mainnet: `/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f/1`

This PR adds the possibility of using {chainName} or {chainId} indistinctly, so it's easier for most users to create their URLs manually => Using {chainName} for the same example:  `/0xde30da39c46104798bb5aa3fe8b9e0e1f348163f/mainnet`

__Some considerations__

- In this initial approach I'm comparing the network name from the URL with `chain.network` from `viem/chains`, but I've realized some networks got a weird `chain.network` (mainnet for example), I solved it with this hacky code: 
`if (normalizedNetwork === "ethereum" || normalizedNetwork === "mainnet") { normalizedNetwork = "homestead"; }`

- Creating local variable `parsedNetworkId` instead of just using the new `chainId` state because I was having problems with the refresh of the value, sometimes was fetching the ABI with the wrong value. 

Not sure if that's the correct way to solve both issues.

## Related Issues

Closes #38 

