### PR TITLE
add middlware to redirect /[contractAddress] requests to mainnet by default

### DIFF
--- a/packages/nextjs/middleware.ts
+++ b/packages/nextjs/middleware.ts
@@ -8,7 +8,7 @@ export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Extract the first path segment after the initial slash, if any.
-  const pathSegments = pathname.split("/").filter(Boolean); // Removes empty strings from the result.
+  const pathSegments = pathname.split("/").filter(Boolean);
 
   // Check if there is exactly one path segment and if it matches the address regex.
   if (pathSegments.length === 1 && addressRegex.test(pathSegments[0])) {

--- a/packages/nextjs/middleware.ts
+++ b/packages/nextjs/middleware.ts
@@ -1,0 +1,21 @@
+import { NextResponse } from "next/server";
+import type { NextRequest } from "next/server";
+
+// Viem's address regex
+const addressRegex = /^0x[a-fA-F0-9]{40}$/;
+
+export function middleware(request: NextRequest) {
+  const { pathname } = request.nextUrl;
+
+  // Extract the first path segment after the initial slash, if any.
+  const pathSegments = pathname.split("/").filter(Boolean); // Removes empty strings from the result.
+
+  // Check if there is exactly one path segment and if it matches the address regex.
+  if (pathSegments.length === 1 && addressRegex.test(pathSegments[0])) {
+    const newURL = new URL(`/${pathSegments[0]}/1`, request.url);
+    return NextResponse.redirect(newURL);
+  }
+
+  // For all other requests, proceed with normal handling.
+  return NextResponse.next();
+}


### PR DESCRIPTION
## Description 

Didn't use `next.config.js` [approach](https://nextjs.org/docs/pages/building-your-application/routing/redirecting#redirects-in-nextconfigjs) of redirecting instead used [middleware](https://nextjs.org/docs/app/building-your-application/routing/middleware) approach since : 

1. The path params are attached direclty to base url eg: `locahost:3000/[contractAddress]` it would have been easy to match if it was `localhost:3000/contract/[contractAddress]`
2. Also wanted to add address regex logic 


Closes #67 