### PR TITLE
Pass undefined to AlchemyProvider

### DIFF
--- a/packages/nextjs/pages/[contractAddress]/[network].tsx
+++ b/packages/nextjs/pages/[contractAddress]/[network].tsx
@@ -77,7 +77,7 @@ const ContractDetailPage = () => {
         }
 
         try {
-          const alchemyProvider = new AlchemyProvider(parseInt(network), scaffoldConfig.alchemyApiKey);
+          const alchemyProvider = new AlchemyProvider(undefined, scaffoldConfig.alchemyApiKey);
           const requestFunc = ({ method, params }: { method: string; params: any }) =>
             alchemyProvider.send(method, params);
           const implementationAddress = await detectProxyTarget(contractAddress, requestFunc);

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -35,7 +35,7 @@ const Home: NextPage = () => {
   const [isCheckingContractAddress, setIsCheckingContractAddress] = useState(false);
   const [isContract, setIsContract] = useState(false);
 
-  const alchemyProvider = new AlchemyProvider(parseInt(network), scaffoldConfig.alchemyApiKey);
+  const alchemyProvider = new AlchemyProvider(undefined, scaffoldConfig.alchemyApiKey);
   const requestFunc = ({ method, params }: { method: string; params: any }) => alchemyProvider.send(method, params);
 
   const publicClient = usePublicClient({


### PR DESCRIPTION
## Description

Pass undefined to AlchemyProvider in both index.tsx and [network].tsx files to prevent the page from crashing.

I have another issue + PR coming up about this, and I fixed this problem by adapting the code to use viem instead of ethers which is more up-to-date in terms of networks and easier to implement. Also added support for Zora contracts, will open an issue as soon as it is ready. 

Tried to provide a remedy as quickly as possible in this PR.

Please see #79 

## Additional Information

- [ ] I have read the [contributing docs](https://github.com/BuidlGuidl/abi.ninja/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/BuidlGuidl/abi.ninja/pulls)

## Related Issues

_Closes #79 _

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
