### PR TITLE
Use viem for detecting proxy contracts logic

### DIFF
--- a/packages/nextjs/package.json
+++ b/packages/nextjs/package.json
@@ -21,7 +21,6 @@
     "@uniswap/v2-sdk": "^3.0.1",
     "blo": "^1.0.1",
     "daisyui": "^4.4.19",
-    "evm-proxy-detection": "^1.2.0",
     "next": "13.3.4",
     "next-plausible": "^3.12.0",
     "nextjs-progressbar": "^0.0.16",

--- a/packages/nextjs/pages/[contractAddress]/[network].tsx
+++ b/packages/nextjs/pages/[contractAddress]/[network].tsx
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import { ParsedUrlQuery } from "querystring";
-import { Abi, extractChain, isAddress } from "viem";
+import { Abi, isAddress } from "viem";
 import * as chains from "viem/chains";
 import { usePublicClient } from "wagmi";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
@@ -22,8 +22,6 @@ type ContractData = {
   abi: Abi;
   address: string;
 };
-
-type AllowedNetwork = (typeof scaffoldConfig.targetNetworks)[number]["id"];
 
 const ContractDetailPage = () => {
   const router = useRouter();

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useRouter } from "next/router";
 import type { NextPage } from "next";
-import { Address, extractChain, isAddress } from "viem";
+import { Address, isAddress } from "viem";
 import { usePublicClient } from "wagmi";
 import { MetaHeader } from "~~/components/MetaHeader";
 import { MiniFooter } from "~~/components/MiniFooter";
@@ -18,8 +18,6 @@ enum TabName {
   verifiedContract,
   addressAbi,
 }
-
-type AllowedNetwork = (typeof scaffoldConfig.targetNetworks)[number]["id"];
 
 const tabValues = Object.values(TabName) as TabName[];
 

--- a/packages/nextjs/utils/abi-ninja/proxyContracts.ts
+++ b/packages/nextjs/utils/abi-ninja/proxyContracts.ts
@@ -1,0 +1,116 @@
+const EIP_1967_LOGIC_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
+const EIP_1967_BEACON_SLOT = "0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50";
+// const OPEN_ZEPPELIN_IMPLEMENTATION_SLOT = "0x7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3";
+const EIP_1822_LOGIC_SLOT = "0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7";
+const EIP_1167_BEACON_METHODS = [
+  "0x5c60da1b00000000000000000000000000000000000000000000000000000000",
+  "0xda52571600000000000000000000000000000000000000000000000000000000",
+];
+const EIP_897_INTERFACE = ["0x5c60da1b00000000000000000000000000000000000000000000000000000000"];
+const GNOSIS_SAFE_PROXY_INTERFACE = ["0xa619486e00000000000000000000000000000000000000000000000000000000"];
+const COMPTROLLER_PROXY_INTERFACE = ["0xbb82aa5e00000000000000000000000000000000000000000000000000000000"];
+
+const readAddress = (value: string): string => {
+  if (typeof value !== "string" || value === "0x") {
+    throw new Error(`Invalid address value: ${value}`);
+  }
+  const address = value.length === 66 ? "0x" + value.slice(-40) : value;
+  const zeroAddress = "0x" + "0".repeat(40);
+  if (address === zeroAddress) {
+    throw new Error("Empty address");
+  }
+  return address;
+};
+
+const EIP_1167_BYTECODE_PREFIX = "0x363d3d373d3d3d363d";
+const EIP_1167_BYTECODE_SUFFIX = "57fd5bf3";
+
+export const parse1167Bytecode = (bytecode: unknown): string => {
+  if (typeof bytecode !== "string" || !bytecode.startsWith(EIP_1167_BYTECODE_PREFIX)) {
+    throw new Error("Not an EIP-1167 bytecode");
+  }
+
+  // detect length of address (20 bytes non-optimized, 0 < N < 20 bytes for vanity addresses)
+  const pushNHex = bytecode.substring(EIP_1167_BYTECODE_PREFIX.length, EIP_1167_BYTECODE_PREFIX.length + 2);
+  // push1 ... push20 use opcodes 0x60 ... 0x73
+  const addressLength = parseInt(pushNHex, 16) - 0x5f;
+
+  if (addressLength < 1 || addressLength > 20) {
+    throw new Error("Not an EIP-1167 bytecode");
+  }
+
+  const addressFromBytecode = bytecode.substring(
+    EIP_1167_BYTECODE_PREFIX.length + 2,
+    EIP_1167_BYTECODE_PREFIX.length + 2 + addressLength * 2, // address length is in bytes, 2 hex chars make up 1 byte
+  );
+
+  const SUFFIX_OFFSET_FROM_ADDRESS_END = 22;
+  if (
+    !bytecode
+      .substring(EIP_1167_BYTECODE_PREFIX.length + 2 + addressLength * 2 + SUFFIX_OFFSET_FROM_ADDRESS_END)
+      .startsWith(EIP_1167_BYTECODE_SUFFIX)
+  ) {
+    throw new Error("Not an EIP-1167 bytecode");
+  }
+
+  // padStart is needed for vanity addresses
+  return `0x${addressFromBytecode.padStart(40, "0")}`;
+};
+
+export const detectProxyTarget = async (proxyAddress: string, client: any): Promise<string | null> => {
+  try {
+    return await Promise.any([
+      (async () => {
+        const bytecode = await client.getBytecode({ address: proxyAddress });
+        return parse1167Bytecode(bytecode);
+      })(),
+      (async () => {
+        const logicAddress = await client.getStorageAt({ address: proxyAddress, slot: EIP_1967_LOGIC_SLOT });
+        return readAddress(logicAddress);
+      })(),
+      (async () => {
+        const beaconAddress = await client.getStorageAt({ address: proxyAddress, slot: EIP_1967_BEACON_SLOT });
+        const resolvedBeaconAddress = readAddress(beaconAddress);
+        for (const method of EIP_1167_BEACON_METHODS) {
+          try {
+            const data = await client.call({ data: method as `0x${string}`, to: resolvedBeaconAddress });
+            return readAddress(data.data);
+          } catch {
+            // Ignore
+          }
+        }
+        throw new Error("Beacon method calls failed");
+      })(),
+    ]);
+  } catch (error) {
+    try {
+      return await Promise.any([
+        (async () => {
+          const logicAddress = await client.getStorageAt({ address: proxyAddress, slot: EIP_1822_LOGIC_SLOT });
+          return readAddress(logicAddress);
+        })(),
+        (async () => {
+          const { data } = await client.call({ data: EIP_897_INTERFACE[0] as `0x${string}`, to: proxyAddress });
+          return readAddress(data);
+        })(),
+        (async () => {
+          const { data } = await client.call({
+            data: GNOSIS_SAFE_PROXY_INTERFACE[0] as `0x${string}`,
+            to: proxyAddress,
+          });
+          return readAddress(data);
+        })(),
+        (async () => {
+          const { data } = await client.call({
+            data: COMPTROLLER_PROXY_INTERFACE[0] as `0x${string}`,
+            to: proxyAddress,
+          });
+          return readAddress(data);
+        })(),
+      ]);
+    } catch (fallbackError) {
+      // @todo can't return null?
+      return null;
+    }
+  }
+};

--- a/packages/nextjs/utils/abi-ninja/proxyContracts.ts
+++ b/packages/nextjs/utils/abi-ninja/proxyContracts.ts
@@ -1,3 +1,5 @@
+import { PublicClient } from "wagmi";
+
 const EIP_1967_LOGIC_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc" as const;
 const EIP_1967_BEACON_SLOT = "0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50" as const;
 // const OPEN_ZEPPELIN_IMPLEMENTATION_SLOT = "0x7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3";
@@ -10,7 +12,7 @@ const EIP_897_INTERFACE = ["0x5c60da1b000000000000000000000000000000000000000000
 const GNOSIS_SAFE_PROXY_INTERFACE = ["0xa619486e00000000000000000000000000000000000000000000000000000000"] as const;
 const COMPTROLLER_PROXY_INTERFACE = ["0xbb82aa5e00000000000000000000000000000000000000000000000000000000"] as const;
 
-const readAddress = (value: string): string => {
+const readAddress = (value: string | undefined) => {
   if (typeof value !== "string" || value === "0x") {
     throw new Error(`Invalid address value: ${value}`);
   }
@@ -57,7 +59,7 @@ export const parse1167Bytecode = (bytecode: unknown): string => {
   return `0x${addressFromBytecode.padStart(40, "0")}`;
 };
 
-export const detectProxyTarget = async (proxyAddress: string, client: any): Promise<string | null> => {
+export const detectProxyTarget = async (proxyAddress: string, client: PublicClient): Promise<string | null> => {
   try {
     return await Promise.any([
       (async () => {

--- a/packages/nextjs/utils/abi-ninja/proxyContracts.ts
+++ b/packages/nextjs/utils/abi-ninja/proxyContracts.ts
@@ -1,14 +1,14 @@
-const EIP_1967_LOGIC_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc";
-const EIP_1967_BEACON_SLOT = "0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50";
+const EIP_1967_LOGIC_SLOT = "0x360894a13ba1a3210667c828492db98dca3e2076cc3735a920a3ca505d382bbc" as const;
+const EIP_1967_BEACON_SLOT = "0xa3f0ad74e5423aebfd80d3ef4346578335a9a72aeaee59ff6cb3582b35133d50" as const;
 // const OPEN_ZEPPELIN_IMPLEMENTATION_SLOT = "0x7050c9e0f4ca769c69bd3a8ef740bc37934f8e2c036e5a723fd8ee048ed3f8c3";
-const EIP_1822_LOGIC_SLOT = "0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7";
+const EIP_1822_LOGIC_SLOT = "0xc5f16f0fcc639fa48a6947836d9850f504798523bf8c9a3a87d5876cf622bcf7" as const;
 const EIP_1167_BEACON_METHODS = [
   "0x5c60da1b00000000000000000000000000000000000000000000000000000000",
   "0xda52571600000000000000000000000000000000000000000000000000000000",
-];
-const EIP_897_INTERFACE = ["0x5c60da1b00000000000000000000000000000000000000000000000000000000"];
-const GNOSIS_SAFE_PROXY_INTERFACE = ["0xa619486e00000000000000000000000000000000000000000000000000000000"];
-const COMPTROLLER_PROXY_INTERFACE = ["0xbb82aa5e00000000000000000000000000000000000000000000000000000000"];
+] as const;
+const EIP_897_INTERFACE = ["0x5c60da1b00000000000000000000000000000000000000000000000000000000"] as const;
+const GNOSIS_SAFE_PROXY_INTERFACE = ["0xa619486e00000000000000000000000000000000000000000000000000000000"] as const;
+const COMPTROLLER_PROXY_INTERFACE = ["0xbb82aa5e00000000000000000000000000000000000000000000000000000000"] as const;
 
 const readAddress = (value: string): string => {
   if (typeof value !== "string" || value === "0x") {
@@ -73,7 +73,7 @@ export const detectProxyTarget = async (proxyAddress: string, client: any): Prom
         const resolvedBeaconAddress = readAddress(beaconAddress);
         for (const method of EIP_1167_BEACON_METHODS) {
           try {
-            const data = await client.call({ data: method as `0x${string}`, to: resolvedBeaconAddress });
+            const data = await client.call({ data: method, to: resolvedBeaconAddress });
             return readAddress(data.data);
           } catch {
             // Ignore
@@ -90,19 +90,19 @@ export const detectProxyTarget = async (proxyAddress: string, client: any): Prom
           return readAddress(logicAddress);
         })(),
         (async () => {
-          const { data } = await client.call({ data: EIP_897_INTERFACE[0] as `0x${string}`, to: proxyAddress });
+          const { data } = await client.call({ data: EIP_897_INTERFACE[0], to: proxyAddress });
           return readAddress(data);
         })(),
         (async () => {
           const { data } = await client.call({
-            data: GNOSIS_SAFE_PROXY_INTERFACE[0] as `0x${string}`,
+            data: GNOSIS_SAFE_PROXY_INTERFACE[0],
             to: proxyAddress,
           });
           return readAddress(data);
         })(),
         (async () => {
           const { data } = await client.call({
-            data: COMPTROLLER_PROXY_INTERFACE[0] as `0x${string}`,
+            data: COMPTROLLER_PROXY_INTERFACE[0],
             to: proxyAddress,
           });
           return readAddress(data);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1370,7 +1370,6 @@ __metadata:
     eslint-config-next: ^13.1.6
     eslint-config-prettier: ^8.5.0
     eslint-plugin-prettier: ^4.2.1
-    evm-proxy-detection: ^1.2.0
     next: 13.3.4
     next-plausible: ^3.12.0
     nextjs-progressbar: ^0.0.16
@@ -4874,13 +4873,6 @@ __metadata:
   version: 3.3.0
   resolution: "events@npm:3.3.0"
   checksum: f6f487ad2198aa41d878fa31452f1a3c00958f46e9019286ff4787c84aac329332ab45c9cdc8c445928fc6d7ded294b9e005a7fce9426488518017831b272780
-  languageName: node
-  linkType: hard
-
-"evm-proxy-detection@npm:^1.2.0":
-  version: 1.2.0
-  resolution: "evm-proxy-detection@npm:1.2.0"
-  checksum: d9996cbcd22eadd0b1209116d1f5c90ebf063edfe08c71c2f92372040dc004248ab280887a2f6d968d3e4963f40909f7f4cece584992e8e1f6ea136d6e18f2ee
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR:

- Migrates the proxy detection logic that we currently use from evm-proxy-detection to viem
- Adds the ability to detect Zora contracts by first checking for EIP-1967

There still might be some rough edges on this PR so feel free to give me some harsh feedback! It helps more that way!

## Additional Information

- [ ] I have read the [contributing docs](https://github.com/BuidlGuidl/abi.ninja/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/BuidlGuidl/abi.ninja/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
