### PR TITLE
remove localnetwork for now

### DIFF
--- a/packages/nextjs/scaffold.config.ts
+++ b/packages/nextjs/scaffold.config.ts
@@ -9,15 +9,9 @@ export type ScaffoldConfig = {
   walletAutoConnect: boolean;
 };
 
-const localhost = {
-  ...chains.localhost,
-  id: 31337,
-} as const;
-
 const scaffoldConfig = {
   // After adding a new chain here we should also add it to the networks.ts file
   targetNetworks: [
-    localhost,
     chains.mainnet,
     chains.sepolia,
     chains.goerli,


### PR DESCRIPTION
## Description

This gives an error when people try to connect through the mobile rainbow wallet : 

![IMG_7845](https://github.com/BuidlGuidl/abi.ninja/assets/80153681/d0f4f5a7-a155-4cde-846b-8fcc09e51c29)


Maybe we can allow lccal network again we migrate to wagmi v2 : https://x.com/rainbowdotme/status/1779930443397337534?s=46&t=3J-S7_iZrqdWSB0sUNFYRA