### PR TITLE
Hotfix: change zkSync to zksync in networks.ts

### DIFF
--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -82,7 +82,7 @@ export const NETWORKS_EXTRA_DATA: Record<string, ChainAttributes> = {
     color: "#5f4bb6",
     etherscanEndpoint: "https://block-explorer-api.testnets.zksync.dev",
     etherscanApiKey: ZKSYNC_ETHERSCAN_API_KEY,
-    icon: "/zkSync.svg",
+    icon: "/zksync.svg",
   },
   [chains.base.id]: {
     color: "#1450EE",

--- a/packages/nextjs/utils/scaffold-eth/networks.ts
+++ b/packages/nextjs/utils/scaffold-eth/networks.ts
@@ -76,7 +76,7 @@ export const NETWORKS_EXTRA_DATA: Record<string, ChainAttributes> = {
     color: "#5f4bb6",
     etherscanEndpoint: "https://block-explorer-api.mainnet.zksync.io",
     etherscanApiKey: ZKSYNC_ETHERSCAN_API_KEY,
-    icon: "/zkSync.svg",
+    icon: "/zksync.svg",
   },
   [chains.zkSyncTestnet.id]: {
     color: "#5f4bb6",


### PR DESCRIPTION
## Description

<img width="458" alt="image" src="https://github.com/BuidlGuidl/abi.ninja/assets/108868128/4112452f-7f7a-40a7-ae3d-29ea9908ec89">

We don't see this on local but in prod the zksync img is not shown. This lead me into thinking that the case is the problem here.

## Additional Information

- [ ] I have read the [contributing docs](https://github.com/BuidlGuidl/abi.ninja/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/BuidlGuidl/abi.ninja/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
