### PR TITLE
feat: Add the ability to add custom chains + see more chains, localnode included

### DIFF
--- a/packages/nextjs/components/NetworksDropdown.tsx
+++ b/packages/nextjs/components/NetworksDropdown.tsx
@@ -15,7 +15,7 @@ type Options = {
 };
 
 type GroupedOptions = Record<
-  "mainnet" | "testnet" | "localhost",
+  "mainnet" | "testnet" | "custom",
   {
     label: string;
     options: Options[];
@@ -38,15 +38,6 @@ const getIconComponent = (iconName: string | undefined) => {
 const networks = getTargetNetworks();
 const groupedOptions = networks.reduce<GroupedOptions>(
   (groups, network) => {
-    if (network.id === 31337) {
-      groups.localhost.options.push({
-        value: network.id,
-        label: network.name,
-        icon: network.icon,
-      });
-      return groups;
-    }
-
     const groupName = network.testnet ? "testnet" : "mainnet";
 
     groups[groupName].options.push({
@@ -60,7 +51,7 @@ const groupedOptions = networks.reduce<GroupedOptions>(
   {
     mainnet: { label: "mainnet", options: [] },
     testnet: { label: "testnet", options: [] },
-    localhost: { label: "localhost", options: [] },
+    custom: { label: "custom", options: [] },
   },
 );
 

--- a/packages/nextjs/components/NetworksDropdown.tsx
+++ b/packages/nextjs/components/NetworksDropdown.tsx
@@ -3,7 +3,6 @@ import Image from "next/image";
 import * as chains from "@wagmi/core/chains";
 import { useTheme } from "next-themes";
 import Select, { MultiValue, SingleValue, components } from "react-select";
-import { defineChain } from "viem";
 import { EyeIcon, PlusIcon, PuzzlePieceIcon } from "@heroicons/react/24/outline";
 import { getTargetNetworks, notification } from "~~/utils/scaffold-eth";
 
@@ -139,19 +138,6 @@ export const NetworksDropdown = ({ onChange }: { onChange: (option: Options | nu
     }
   }, []);
 
-  useEffect(() => {
-    customChains.forEach(chain => {
-      defineChain({
-        id: chain.value as number,
-        name: chain.label,
-        //@ts-ignore : weird error here, ignoring for now
-        rpcUrls: {
-          default: { http: [chain.rpcUrl as string] },
-        },
-      });
-    });
-  }, [customChains]);
-
   const handleSelectChange = (newValue: SingleValue<Options> | MultiValue<Options>) => {
     const selected = newValue as SingleValue<Options>;
     if (selected?.value === "see-all") {
@@ -173,12 +159,11 @@ export const NetworksDropdown = ({ onChange }: { onChange: (option: Options | nu
       return;
     }
 
-    const chain = defineChain(newChain);
     const chainOption: Options = {
-      value: chain.id,
-      label: chain.name,
+      value: newChain.id,
+      label: newChain.name,
       icon: "PuzzlePieceIcon",
-      rpcUrl: chain.rpcUrl,
+      rpcUrl: newChain.rpcUrl,
     };
     const updatedChains = [...customChains, chainOption];
     setCustomChains(updatedChains);

--- a/packages/nextjs/components/NetworksDropdown.tsx
+++ b/packages/nextjs/components/NetworksDropdown.tsx
@@ -1,16 +1,16 @@
-import { useEffect, useState } from "react";
+import { ReactNode, useEffect, useState } from "react";
 import Image from "next/image";
 import * as chains from "@wagmi/core/chains";
 import { useTheme } from "next-themes";
 import Select, { MultiValue, SingleValue, components } from "react-select";
 import { defineChain } from "viem";
-import { TrashIcon } from "@heroicons/react/24/outline";
+import { EyeIcon, PlusIcon, PuzzlePieceIcon } from "@heroicons/react/24/outline";
 import { getTargetNetworks } from "~~/utils/scaffold-eth";
 
 type Options = {
   value: number | string;
   label: string;
-  icon?: string;
+  icon?: string | ReactNode;
   rpcUrl?: string;
 };
 
@@ -54,19 +54,19 @@ const groupedOptions = networks.reduce<GroupedOptions>(
 groupedOptions.mainnet.options.push({
   value: "see-all",
   label: "See All Chains",
-  icon: "/mainnet.svg",
+  icon: <EyeIcon className="h-6 w-6 mr-2 text-gray-500" />,
 });
 
 groupedOptions.mainnet.options.push({
   value: "add-custom-chain",
   label: "Add Custom Chain",
-  icon: "/mainnet.svg",
+  icon: <PlusIcon className="h-6 w-6 mr-2 text-gray-500" />,
 });
 
 const allChains = Object.values(chains).map(chain => ({
   value: chain.id,
   label: chain.name,
-  icon: "/mainnet.svg",
+  icon: "",
 }));
 
 const { Option } = components;
@@ -84,16 +84,27 @@ const CustomOption = (props: any) => {
     <Option {...props}>
       <div className="flex items-center justify-between">
         <div className="flex items-center">
-          <Image
-            src={props.data.icon || "/mainnet.svg"}
-            alt={props.data.label}
-            width={24}
-            height={24}
-            className="mr-2"
-          />
+          {typeof props.data.icon === "string" ? (
+            <Image
+              src={props.data.icon || "/mainnet.svg"}
+              alt={props.data.label}
+              width={24}
+              height={24}
+              className="mr-2"
+            />
+          ) : (
+            props.data.icon
+          )}
           {props.data.label}
         </div>
-        {props.data.rpcUrl && <TrashIcon className="h-4 w-4 text-red-500 cursor-pointer" onClick={handleDelete} />}
+        {props.data.rpcUrl && (
+          <div
+            className="h-4 w-4 text-red-500 cursor-pointer font-bold flex items-center justify-center"
+            onClick={handleDelete}
+          >
+            ✕
+          </div>
+        )}
       </div>
     </Option>
   );
@@ -164,6 +175,7 @@ export const NetworksDropdown = ({ onChange }: { onChange: (option: Options | nu
     const chainOption: Options = {
       value: chain.id,
       label: chain.name,
+      icon: <PuzzlePieceIcon className="h-6 w-6 mr-2 text-gray-500" />,
       rpcUrl: chain.rpcUrl,
     };
     const updatedChains = [...customChains, chainOption];

--- a/packages/nextjs/components/NetworksDropdown.tsx
+++ b/packages/nextjs/components/NetworksDropdown.tsx
@@ -5,7 +5,7 @@ import { useTheme } from "next-themes";
 import Select, { MultiValue, SingleValue, components } from "react-select";
 import { defineChain } from "viem";
 import { EyeIcon, PlusIcon, PuzzlePieceIcon } from "@heroicons/react/24/outline";
-import { getTargetNetworks } from "~~/utils/scaffold-eth";
+import { getTargetNetworks, notification } from "~~/utils/scaffold-eth";
 
 type Options = {
   value: number | string;
@@ -174,6 +174,14 @@ export const NetworksDropdown = ({ onChange }: { onChange: (option: Options | nu
   };
 
   const handleAddCustomChain = (newChain: any) => {
+    const existingChain =
+      allChains.find(chain => chain.value === newChain.id) || customChains.find(chain => chain.value === newChain.id);
+
+    if (existingChain) {
+      notification.error(`This chain already exists with the name: ${existingChain.label}`);
+      return;
+    }
+
     const chain = defineChain(newChain);
     const chainOption: Options = {
       value: chain.id,

--- a/packages/nextjs/components/NetworksDropdown.tsx
+++ b/packages/nextjs/components/NetworksDropdown.tsx
@@ -22,6 +22,19 @@ type GroupedOptions = Record<
   }
 >;
 
+const getIconComponent = (iconName: string | undefined) => {
+  switch (iconName) {
+    case "EyeIcon":
+      return <EyeIcon className="h-6 w-6 mr-2 text-gray-500" />;
+    case "PlusIcon":
+      return <PlusIcon className="h-6 w-6 mr-2 text-gray-500" />;
+    case "PuzzlePieceIcon":
+      return <PuzzlePieceIcon className="h-6 w-6 mr-2 text-gray-500" />;
+    default:
+      return <Image src={iconName || "/mainnet.svg"} alt="default icon" width={24} height={24} className="mr-2" />;
+  }
+};
+
 const networks = getTargetNetworks();
 const groupedOptions = networks.reduce<GroupedOptions>(
   (groups, network) => {
@@ -54,13 +67,13 @@ const groupedOptions = networks.reduce<GroupedOptions>(
 groupedOptions.mainnet.options.push({
   value: "see-all",
   label: "See All Chains",
-  icon: <EyeIcon className="h-6 w-6 mr-2 text-gray-500" />,
+  icon: "EyeIcon",
 });
 
 groupedOptions.mainnet.options.push({
   value: "add-custom-chain",
   label: "Add Custom Chain",
-  icon: <PlusIcon className="h-6 w-6 mr-2 text-gray-500" />,
+  icon: "PlusIcon",
 });
 
 const allChains = Object.values(chains).map(chain => ({
@@ -84,17 +97,7 @@ const CustomOption = (props: any) => {
     <Option {...props}>
       <div className="flex items-center justify-between">
         <div className="flex items-center">
-          {typeof props.data.icon === "string" ? (
-            <Image
-              src={props.data.icon || "/mainnet.svg"}
-              alt={props.data.label}
-              width={24}
-              height={24}
-              className="mr-2"
-            />
-          ) : (
-            props.data.icon
-          )}
+          {typeof props.data.icon === "string" ? getIconComponent(props.data.icon) : props.data.icon}
           {props.data.label}
         </div>
         {props.data.rpcUrl && (
@@ -175,7 +178,7 @@ export const NetworksDropdown = ({ onChange }: { onChange: (option: Options | nu
     const chainOption: Options = {
       value: chain.id,
       label: chain.name,
-      icon: <PuzzlePieceIcon className="h-6 w-6 mr-2 text-gray-500" />,
+      icon: "PuzzlePieceIcon",
       rpcUrl: chain.rpcUrl,
     };
     const updatedChains = [...customChains, chainOption];

--- a/packages/nextjs/components/NetworksDropdown.tsx
+++ b/packages/nextjs/components/NetworksDropdown.tsx
@@ -1,11 +1,12 @@
 import { useEffect, useState } from "react";
 import Image from "next/image";
+import * as chains from "@wagmi/core/chains";
 import { useTheme } from "next-themes";
-import Select, { OptionProps, components } from "react-select";
+import Select, { MultiValue, OptionProps, SingleValue, components } from "react-select";
 import { getTargetNetworks } from "~~/utils/scaffold-eth";
 
 type Options = {
-  value: number;
+  value: number | string;
   label: string;
   icon?: string;
 };
@@ -20,7 +21,6 @@ type GroupedOptions = Record<
 const networks = getTargetNetworks();
 const groupedOptions = networks.reduce<GroupedOptions>(
   (groups, network) => {
-    // Handle the case for localhost
     if (network.id === 31337) {
       groups.localhost.options.push({
         value: network.id,
@@ -47,6 +47,18 @@ const groupedOptions = networks.reduce<GroupedOptions>(
   },
 );
 
+groupedOptions.mainnet.options.push({
+  value: "see-all",
+  label: "See All Chains",
+  icon: "/mainnet.svg",
+});
+
+const allChains = Object.values(chains).map(chain => ({
+  value: chain.id,
+  label: chain.name,
+  icon: "/mainnet.svg",
+}));
+
 const { Option } = components;
 const IconOption = (props: OptionProps<Options>) => (
   <Option {...props}>
@@ -57,9 +69,11 @@ const IconOption = (props: OptionProps<Options>) => (
   </Option>
 );
 
-export const NetworksDropdown = ({ onChange }: { onChange: (options: any) => any }) => {
+export const NetworksDropdown = ({ onChange }: { onChange: (option: Options | null) => void }) => {
   const [isMobile, setIsMobile] = useState(false);
   const { resolvedTheme } = useTheme();
+  const [selectedOption, setSelectedOption] = useState<SingleValue<Options>>(groupedOptions.mainnet.options[0]);
+  const [searchTerm, setSearchTerm] = useState("");
 
   const isDarkMode = resolvedTheme === "dark";
 
@@ -80,36 +94,95 @@ export const NetworksDropdown = ({ onChange }: { onChange: (options: any) => any
     }
   }, []);
 
+  const handleSelectChange = (newValue: SingleValue<Options> | MultiValue<Options>) => {
+    const selected = newValue as SingleValue<Options>;
+    if (selected?.value === "see-all") {
+      (document.getElementById("see-all-modal") as HTMLDialogElement)?.showModal();
+    } else {
+      setSelectedOption(selected);
+      onChange(selected);
+    }
+  };
+
+  const filteredChains = allChains.filter(chain => chain.label.toLowerCase().includes(searchTerm.toLowerCase()));
+
+  console.log({ filteredChains });
+
   if (!mounted) return null;
+
   return (
-    <Select
-      defaultValue={groupedOptions["mainnet"].options[0]}
-      instanceId="network-select"
-      options={Object.values(groupedOptions)}
-      onChange={onChange}
-      components={{ Option: IconOption }}
-      isSearchable={!isMobile}
-      className="max-w-xs relative text-sm w-44"
-      theme={theme => ({
-        ...theme,
-        colors: {
-          ...theme.colors,
-          primary25: isDarkMode ? "#401574" : "#efeaff",
-          primary50: isDarkMode ? "#551d98" : "#c1aeff",
-          primary: isDarkMode ? "#BA8DE8" : "#551d98",
-          neutral0: isDarkMode ? "#130C25" : theme.colors.neutral0,
-          neutral80: isDarkMode ? "#ffffff" : theme.colors.neutral80,
-        },
-      })}
-      styles={{
-        menuList: provided => ({ ...provided, maxHeight: 280, overflow: "auto" }),
-        control: provided => ({ ...provided, borderRadius: 12 }),
-        indicatorSeparator: provided => ({ ...provided, display: "none" }),
-        menu: provided => ({
-          ...provided,
-          border: `1px solid ${isDarkMode ? "#555555" : "#a3a3a3"}`,
-        }),
-      }}
-    />
+    <>
+      <Select
+        value={selectedOption}
+        instanceId="network-select"
+        options={Object.values(groupedOptions)}
+        onChange={handleSelectChange}
+        components={{ Option: IconOption }}
+        isSearchable={!isMobile}
+        className="max-w-xs relative text-sm w-44"
+        theme={theme => ({
+          ...theme,
+          colors: {
+            ...theme.colors,
+            primary25: isDarkMode ? "#401574" : "#efeaff",
+            primary50: isDarkMode ? "#551d98" : "#c1aeff",
+            primary: isDarkMode ? "#BA8DE8" : "#551d98",
+            neutral0: isDarkMode ? "#130C25" : theme.colors.neutral0,
+            neutral80: isDarkMode ? "#ffffff" : theme.colors.neutral80,
+          },
+        })}
+        styles={{
+          menuList: provided => ({ ...provided, maxHeight: 280, overflow: "auto" }),
+          control: provided => ({ ...provided, borderRadius: 12 }),
+          indicatorSeparator: provided => ({ ...provided, display: "none" }),
+          menu: provided => ({
+            ...provided,
+            border: `1px solid ${isDarkMode ? "#555555" : "#a3a3a3"}`,
+          }),
+        }}
+      />
+
+      <dialog id="see-all-modal" className="modal">
+        <div className="flex flex-col modal-box p-12 h-3/4 w-11/12 max-w-5xl bg-base-200">
+          <div className="flex justify-between items-center mb-6">
+            <h3 className="font-bold text-xl">All Chains</h3>
+            <div className="modal-action mt-0">
+              <button
+                className="btn btn-error"
+                onClick={() => (document.getElementById("see-all-modal") as HTMLDialogElement)?.close()}
+              >
+                Close
+              </button>
+            </div>
+          </div>
+          <input
+            type="text"
+            placeholder="Search chains..."
+            className="input input-bordered w-full mb-4 bg-neutral"
+            value={searchTerm}
+            onChange={e => setSearchTerm(e.target.value)}
+          />
+
+          <div className="flex flex-wrap content-start justify-center gap-4 overflow-y-auto h-3/4 p-2">
+            {filteredChains.map(option => (
+              <div
+                key={`${option.label}-${option.value}`}
+                className="card shadow-md bg-base-100 cursor-pointer h-28 w-60 text-center"
+                onClick={() => {
+                  setSelectedOption(option);
+                  onChange(option);
+                  (document.getElementById("see-all-modal") as HTMLDialogElement)?.close();
+                }}
+              >
+                <div className="card-body flex flex-col justify-center items-center p-4">
+                  <span className="text-sm font-semibold">Chain Id: {option.value}</span>
+                  <span className="text-sm">{option.label}</span>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </dialog>
+    </>
   );
 };

--- a/packages/nextjs/components/NetworksDropdown.tsx
+++ b/packages/nextjs/components/NetworksDropdown.tsx
@@ -197,6 +197,7 @@ export const NetworksDropdown = ({ onChange }: { onChange: (option: Options | nu
       rpcUrl: formData.get("rpcUrl") as string,
     };
     handleAddCustomChain(newChain);
+    e.currentTarget.reset();
     (document.getElementById("add-custom-chain-modal") as HTMLDialogElement)?.close();
   };
 

--- a/packages/nextjs/components/NetworksDropdown.tsx
+++ b/packages/nextjs/components/NetworksDropdown.tsx
@@ -6,7 +6,7 @@ import Select, { MultiValue, SingleValue, components } from "react-select";
 import { EyeIcon, PlusIcon, PuzzlePieceIcon } from "@heroicons/react/24/outline";
 import { getTargetNetworks, notification } from "~~/utils/scaffold-eth";
 
-type Options = {
+export type Options = {
   value: number | string;
   label: string;
   icon?: string | ReactNode;

--- a/packages/nextjs/components/NetworksDropdown.tsx
+++ b/packages/nextjs/components/NetworksDropdown.tsx
@@ -258,7 +258,7 @@ export const NetworksDropdown = ({ onChange }: { onChange: (option: Options | nu
       />
 
       <dialog id="see-all-modal" className="modal">
-        <div className="flex flex-col modal-box p-12 h-3/4 w-11/12 max-w-5xl bg-base-200">
+        <div className="flex flex-col modal-box justify-center p-12 h-3/4 w-11/12 max-w-5xl bg-base-200">
           <div className="flex justify-between items-center mb-6">
             <h3 className="font-bold text-xl">All Chains</h3>
             <div className="modal-action mt-0">
@@ -278,7 +278,7 @@ export const NetworksDropdown = ({ onChange }: { onChange: (option: Options | nu
             onChange={e => setSearchTerm(e.target.value)}
           />
 
-          <div className="flex flex-wrap content-start justify-center gap-4 overflow-y-auto h-3/4 p-2">
+          <div className="flex flex-wrap content-start justify-center gap-4 overflow-y-auto h-5/6 p-2">
             {filteredChains.map(option => (
               <div
                 key={`${option.label}-${option.value}`}

--- a/packages/nextjs/pages/[contractAddress]/[network].tsx
+++ b/packages/nextjs/pages/[contractAddress]/[network].tsx
@@ -3,17 +3,18 @@ import Link from "next/link";
 import { useRouter } from "next/router";
 import { GetServerSideProps } from "next";
 import { ParsedUrlQuery } from "querystring";
-import { Abi, isAddress } from "viem";
+import { Abi, createPublicClient, defineChain, http, isAddress } from "viem";
 import * as chains from "viem/chains";
-import { usePublicClient } from "wagmi";
 import { ExclamationTriangleIcon } from "@heroicons/react/24/outline";
 import { MetaHeader } from "~~/components/MetaHeader";
 import { MiniHeader } from "~~/components/MiniHeader";
+import { Options } from "~~/components/NetworksDropdown";
 import { SwitchTheme } from "~~/components/SwitchTheme";
 import { ContractUI } from "~~/components/scaffold-eth";
 import { useAbiNinjaState } from "~~/services/store/store";
-import { fetchContractABIFromAnyABI, fetchContractABIFromEtherscan } from "~~/utils/abi";
+import { fetchContractABIFromAnyABI, fetchContractABIFromEtherscan, parseAndCorrectJSON } from "~~/utils/abi";
 import { detectProxyTarget } from "~~/utils/abi-ninja/proxyContracts";
+import { notification } from "~~/utils/scaffold-eth";
 
 interface ParsedQueryContractDetailsPage extends ParsedUrlQuery {
   contractAddress: string;
@@ -52,6 +53,8 @@ const ContractDetailPage = ({ addressFromUrl, chainIdFromUrl }: ServerSideProps)
   const [contractData, setContractData] = useState<ContractData>({ abi: [], address: contractAddress });
   const [isLoading, setIsLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [localContractAbi, setLocalContractAbi] = useState("");
+  const [customChains, setCustomChains] = useState<Options[]>([]);
   const contractName = contractData.address;
   const {
     contractAbi: storedAbi,
@@ -65,13 +68,54 @@ const ContractDetailPage = ({ addressFromUrl, chainIdFromUrl }: ServerSideProps)
     setImplementationAddress: state.setImplementationAddress,
   }));
 
-  const publicClient = usePublicClient({
-    chainId: parseInt(network),
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      const customChains = JSON.parse(localStorage.getItem("customChains") || "[]");
+      setCustomChains(customChains);
+    }
+  }, []);
+
+  let selectedChain = Object.values(chains).find(chain => chain.id === parseInt(network));
+  if (!selectedChain) {
+    const customChain = customChains.find((chain: any) => chain.value === chainId);
+    if (customChain) {
+      // @ts-ignore
+      selectedChain = defineChain({
+        id: +customChain.value,
+        name: customChain.label,
+        nativeCurrency: {
+          decimals: 18,
+          name: customChain.label,
+          symbol: customChain.label,
+        },
+        rpcUrls: {
+          default: {
+            http: [customChain.rpcUrl as string],
+          },
+          public: {
+            http: [customChain.rpcUrl as string],
+          },
+        },
+        network: customChain.label, // shouldn't be necessary according to docs, but it is
+      });
+    } else {
+      selectedChain = Object.values(chains).find(chain => chain.id === 1);
+    }
+  }
+
+  const publicClient = createPublicClient({
+    chain: selectedChain,
+    transport: http(),
   });
 
   const getNetworkName = (chainId: number) => {
-    const chain = Object.values(chains).find(chain => chain.id === chainId);
-    return chain ? chain.name : "Unknown Network";
+    const predefinedChain = Object.values(chains).find(chain => chain.id === chainId);
+    if (predefinedChain) {
+      return predefinedChain.name;
+    }
+
+    const customChain = customChains.find(chain => chain.value === chainId);
+    return customChain ? customChain.label : "Unknown Network";
   };
 
   useEffect(() => {
@@ -103,6 +147,7 @@ const ContractDetailPage = ({ addressFromUrl, chainIdFromUrl }: ServerSideProps)
         }
 
         try {
+          // @ts-ignore
           const implementationAddress = await detectProxyTarget(contractAddress, publicClient);
 
           if (implementationAddress) {
@@ -138,7 +183,44 @@ const ContractDetailPage = ({ addressFromUrl, chainIdFromUrl }: ServerSideProps)
         }
       }
     }
-  }, [contractAddress, network, storedAbi, setMainChainId, setImplementationAddress, publicClient]);
+  }, []);
+
+  const handleUserProvidedAbi = () => {
+    try {
+      const parsedAbi = parseAndCorrectJSON(localContractAbi);
+      setContractData({ abi: parsedAbi, address: contractAddress });
+      notification.success("ABI successfully loaded.");
+    } catch (error) {
+      notification.error("Invalid ABI format. Please ensure it is a valid JSON.");
+    }
+  };
+
+  const handleAddCustomChain = (newChain: any) => {
+    const chainOption = {
+      value: newChain.id,
+      label: newChain.name,
+      icon: "PuzzlePieceIcon",
+      rpcUrl: newChain.rpcUrl,
+    };
+    const updatedChains = [...customChains, chainOption];
+    setCustomChains(updatedChains);
+    if (typeof window !== "undefined") {
+      localStorage.setItem("customChains", JSON.stringify(updatedChains));
+    }
+  };
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    const formData = new FormData(e.currentTarget);
+    const newChain = {
+      id: parseInt(formData.get("id") as string),
+      name: formData.get("name") as string,
+      rpcUrl: formData.get("rpcUrl") as string,
+    };
+    handleAddCustomChain(newChain);
+    handleUserProvidedAbi();
+    e.currentTarget.reset();
+  };
 
   return (
     <>
@@ -153,16 +235,83 @@ const ContractDetailPage = ({ addressFromUrl, chainIdFromUrl }: ServerSideProps)
           ) : contractData.abi?.length > 0 ? (
             <ContractUI key={contractName} initialContractData={contractData} />
           ) : (
-            <div className="bg-base-200 border shadow-xl rounded-2xl px-6 lg:px-8 m-4">
+            <div className="bg-base-200 flex flex-col border shadow-xl rounded-2xl px-6 lg:px-8 m-4">
               <ExclamationTriangleIcon className="text-red-500 mt-4 h-8 w-8" />
               <h2 className="text-2xl pt-2 flex items-end">{error}</h2>
               <p className="break-all">
                 There was an error loading the contract <strong>{contractAddress}</strong> on{" "}
                 <strong>{getNetworkName(chainId)}</strong>.
               </p>
-              <p className="pb-2">Make sure the data is correct and you are connected to the right network.</p>
+              <p className="pb-2">
+                Make sure the data is correct and you are connected to the right network. Or add the chain/ABI below.
+              </p>
+              <div className="flex justify-center gap-12">
+                {customChains.some(chain => chain.value === chainId) ? (
+                  <div className="w-1/2">
+                    <form className="bg-base-200" onSubmit={handleSubmit}>
+                      <h3 className="font-bold text-xl">Add Custom ABI</h3>
+                      <div className="form-control">
+                        <label className="label">
+                          <span className="label-text">ABI</span>
+                        </label>
+                        <textarea
+                          className="textarea bg-neutral w-full h-full mb-4 resize-none"
+                          placeholder="Paste contract ABI in JSON format here"
+                          value={localContractAbi}
+                          onChange={e => setLocalContractAbi(e.target.value)}
+                        ></textarea>
+                      </div>
+                      <div className="modal-action mt-6">
+                        <button type="submit" className="btn btn-primary">
+                          Submit ABI
+                        </button>
+                      </div>
+                    </form>
+                  </div>
+                ) : (
+                  <div className="w-1/2">
+                    <form className="bg-base-200" onSubmit={handleSubmit}>
+                      <h3 className="font-bold text-xl">Add Custom Chain and ABI</h3>
+                      <div className="form-control">
+                        <label className="label">
+                          <span className="label-text">Chain ID</span>
+                        </label>
+                        <input type="number" name="id" className="input input-bordered bg-neutral" required />
+                      </div>
+                      <div className="form-control">
+                        <label className="label">
+                          <span className="label-text">Name</span>
+                        </label>
+                        <input type="text" name="name" className="input input-bordered bg-neutral" required />
+                      </div>
+                      <div className="form-control">
+                        <label className="label">
+                          <span className="label-text">RPC URL</span>
+                        </label>
+                        <input type="text" name="rpcUrl" className="input input-bordered bg-neutral" required />
+                      </div>
+                      <div className="form-control">
+                        <label className="label">
+                          <span className="label-text">ABI</span>
+                        </label>
+                        <textarea
+                          className="textarea bg-neutral w-full h-full mb-4 resize-none"
+                          placeholder="Paste contract ABI in JSON format here"
+                          value={localContractAbi}
+                          onChange={e => setLocalContractAbi(e.target.value)}
+                        ></textarea>
+                      </div>
+                      <div className="modal-action mt-6">
+                        <button type="submit" className="btn btn-primary">
+                          Submit Chain and Import ABI
+                        </button>
+                      </div>
+                    </form>
+                  </div>
+                )}
+              </div>
 
-              <button className="btn btn-primary text-center p-2 text-base border-2 mb-4">
+              <button className="btn btn-ghost text-center self-end p-2 text-base border-2 mb-4">
                 <Link href="/">Go back to homepage</Link>
               </button>
             </div>

--- a/packages/nextjs/pages/[contractAddress]/[network].tsx
+++ b/packages/nextjs/pages/[contractAddress]/[network].tsx
@@ -248,7 +248,7 @@ const ContractDetailPage = ({ addressFromUrl, chainIdFromUrl }: ServerSideProps)
               <div className="flex justify-center gap-12">
                 {customChains.some(chain => chain.value === chainId) ? (
                   <div className="w-1/2">
-                    <form className="bg-base-200" onSubmit={handleSubmit}>
+                    <form className="bg-base-200" onSubmit={handleUserProvidedAbi}>
                       <h3 className="font-bold text-xl">Add Custom ABI</h3>
                       <div className="form-control">
                         <label className="label">

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -95,6 +95,7 @@ const Home: NextPage = () => {
     if (isAddress(verifiedContractAddress)) {
       if (network === "31337") {
         setActiveTab(TabName.addressAbi);
+        setLocalAbiContractAddress(verifiedContractAddress);
         return;
       }
       fetchContractAbi();

--- a/packages/nextjs/utils/abi.ts
+++ b/packages/nextjs/utils/abi.ts
@@ -1,10 +1,6 @@
-import { NETWORKS_EXTRA_DATA, getTargetNetworks } from "./scaffold-eth";
+import { NETWORKS_EXTRA_DATA } from "./scaffold-eth";
 
 export const fetchContractABIFromAnyABI = async (verifiedContractAddress: string, chainId: number) => {
-  const chain = getTargetNetworks().find(network => network.id === chainId);
-
-  if (!chain) throw new Error(`ChainId ${chainId} not found in supported networks`);
-
   const url = `https://anyabi.xyz/api/get-abi/${chainId}/${verifiedContractAddress}`;
 
   const response = await fetch(url);


### PR DESCRIPTION
## Description


### TO-DO

- [x] fix "not found in supported etherscan networks" error
- [x] ask the user for an abi if we cannot get it from etherscan?
- [ ] READ and WRITE functions for custom chains DO NOT WORK (need a way to update the wagmi provider with the custom chains! or initiate it in the components
- [ ] maybe save the custom abi to localStorage?


### This PR

- Adds a See More Chains option to NetworksDropdown
- Adds a Add Custom Chain option to NetworksDropdown
- Enables interacting with contracts on local nodes by entering an ABI

### Known issues in PR:

- had to ignore two type errors in NetworksDropdown.tsx
- needs more testing

## Additional Information

- [ ] I have read the [contributing docs](https://github.com/BuidlGuidl/abi.ninja/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/BuidlGuidl/abi.ninja/pulls)

## Related Issues

_Closes #97 

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
