### PR TITLE
Add skeleton loader when loading networks + Resize abi ninja logo

### DIFF
--- a/packages/nextjs/components/NetworksDropdown.tsx
+++ b/packages/nextjs/components/NetworksDropdown.tsx
@@ -80,7 +80,7 @@ export const NetworksDropdown = ({ onChange }: { onChange: (options: any) => any
     }
   }, []);
 
-  if (!mounted) return <div className="skeleton max-w-xs w-44 relative h-[38px]" />;
+  if (!mounted) return <div className="skeleton bg-neutral max-w-xs w-44 relative h-[38px]" />;
   return (
     <Select
       defaultValue={groupedOptions["mainnet"].options[0]}

--- a/packages/nextjs/components/NetworksDropdown.tsx
+++ b/packages/nextjs/components/NetworksDropdown.tsx
@@ -80,7 +80,7 @@ export const NetworksDropdown = ({ onChange }: { onChange: (options: any) => any
     }
   }, []);
 
-  if (!mounted) return null;
+  if (!mounted) return <div className="skeleton max-w-xs w-44 relative h-[38px]" />;
   return (
     <Select
       defaultValue={groupedOptions["mainnet"].options[0]}

--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -175,13 +175,12 @@ const Home: NextPage = () => {
               >
                 {tabValue === TabName.verifiedContract ? (
                   <div className="my-16 flex flex-col items-center justify-center">
-                    <Image src="/logo_inv.svg" alt="logo" width={128} height={128} className="mb-4" />
+                    <Image src="/logo_inv.svg" alt="logo" width={119} height={87} className="mb-4" />{" "}
                     <h2 className="mb-0 text-5xl font-bold">ABI Ninja</h2>
                     <p>Interact with any contract on Ethereum</p>
                     <div className="mt-4">
                       <NetworksDropdown onChange={option => setNetwork(option ? option.value.toString() : "")} />
                     </div>
-
                     <div className="w-10/12 my-8">
                       <AddressInput
                         placeholder="Contract address"
@@ -189,7 +188,6 @@ const Home: NextPage = () => {
                         onChange={setVerifiedContractAddress}
                       />
                     </div>
-
                     <button
                       className="btn btn-primary min-h-fit h-10 px-4 text-base font-semibold border-2 hover:bg-neutral hover:text-primary"
                       onClick={handleLoadContract}


### PR DESCRIPTION
## Description

Adds a skeleton loader for networks.

I set the height to exactly 38 pixels because that is the size that `react-select` has the select menu set at. I'm not sure if this is the best approach, but I think it works.

## Additional Information

- [x] I have read the [contributing docs](https://github.com/BuidlGuidl/abi.ninja/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/BuidlGuidl/abi.ninja/pulls)

## Related Issues

_Closes #98_

Your ENS/address: `byteatatime.eth`
