### PR TITLE
Add tooltip-info and shadow-lg to the tooltip div

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Input/IntegerInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/IntegerInput.tsx
@@ -46,7 +46,7 @@ export const IntegerInput = ({
         !inputError &&
         !disableMultiplyBy1e18 && (
           <div
-            className="space-x-4 flex tooltip tooltip-top tooltip-info before:shadow-lg before:content-[attr(data-tip)] before:right-[-10px] before:left-auto before:transform-none"
+            className="space-x-4 flex tooltip tooltip-top before:shadow-lg before:content-[attr(data-tip)] before:right-[-10px] before:left-auto before:transform-none"
             data-tip="Multiply by 10^18 (wei)"
           >
             <button

--- a/packages/nextjs/components/scaffold-eth/Input/IntegerInput.tsx
+++ b/packages/nextjs/components/scaffold-eth/Input/IntegerInput.tsx
@@ -46,7 +46,7 @@ export const IntegerInput = ({
         !inputError &&
         !disableMultiplyBy1e18 && (
           <div
-            className="space-x-4 flex tooltip tooltip-top tooltip-secondary before:content-[attr(data-tip)] before:right-[-10px] before:left-auto before:transform-none"
+            className="space-x-4 flex tooltip tooltip-top tooltip-info before:shadow-lg before:content-[attr(data-tip)] before:right-[-10px] before:left-auto before:transform-none"
             data-tip="Multiply by 10^18 (wei)"
           >
             <button

--- a/packages/nextjs/tailwind.config.js
+++ b/packages/nextjs/tailwind.config.js
@@ -58,7 +58,8 @@ module.exports = {
 
           ".tooltip": {
             "--tooltip-tail": "6px",
-            "--tooltip-color": "hsl(var(--p))",
+            "--tooltip-color": "oklch(var(--s))",
+            "--tooltip-text-color": "oklch(var(--sc))",
           },
           ".link": {
             textUnderlineOffset: "2px",


### PR DESCRIPTION
## Description

Adds a tooltip-info color to the tooltip div. 
Also added some shadow to make it stand out more in light theme


<p align="center">
  <b>Before</b><br>
  <img src="https://github.com/BuidlGuidl/abi.ninja/assets/108868128/0dbb9d5b-7206-4e06-801d-879382815e73" width="45%">
  <img src="https://github.com/BuidlGuidl/abi.ninja/assets/108868128/277b0610-81a9-43a5-bd23-a534f5ee1db2" width="45%">
</p>

<p align="center">
  <b>After</b><br>
  <img src="https://github.com/BuidlGuidl/abi.ninja/assets/108868128/7aac4ecd-0712-4c05-b3a8-94266535cede" width="45%">
  <img src="https://github.com/BuidlGuidl/abi.ninja/assets/108868128/02651592-edc6-4b5c-8ded-9a74ef6ad159" width="45%">
</p>



## Additional Information

- [ ] I have read the [contributing docs](https://github.com/BuidlGuidl/abi.ninja/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/BuidlGuidl/abi.ninja/pulls)

## Related Issues

_Closes #122 

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
