### PR TITLE
Update heimdall backend url

### DIFF
--- a/packages/nextjs/pages/index.tsx
+++ b/packages/nextjs/pages/index.tsx
@@ -134,7 +134,10 @@ const Home: NextPage = () => {
   const fetchAbiFromHeimdall = async (contractAddress: Address) => {
     setIsFetchingAbi(true);
     try {
-      const response = await fetch(`${process.env.NEXT_PUBLIC_HEIMDALL_URL}/${network}/${contractAddress}`);
+      const rpcUrlWithoutHttps = publicClient?.chain.rpcUrls.default.http[0].substring(8);
+      const response = await fetch(
+        `${process.env.NEXT_PUBLIC_HEIMDALL_URL}/${contractAddress}?rpc_url=${rpcUrlWithoutHttps}`,
+      );
       const abi = await response.json();
       if (abi.length === 0) {
         notification.error("Failed to fetch ABI from Heimdall. Please try again or enter ABI manually.");


### PR DESCRIPTION
## Description

Uses the new url structure and can use https://heimdall-api-v2.fly.dev/ as an env var.

The new url is already added as an env var to the project at vercel.
It is live at: https://abi-ninja-v2-ewpdbpx46-buidlguidldao.vercel.app/

## Additional Information

- [ ] I have read the [contributing docs](https://github.com/BuidlGuidl/abi.ninja/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/BuidlGuidl/abi.ninja/pulls)

## Related Issues

_Closes #133 

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
