### PR TITLE
Type to find networks instead of choosing them by role="option" in cypress tests

### DIFF
--- a/packages/nextjs/cypress/e2e/contract_interaction.cy.ts
+++ b/packages/nextjs/cypress/e2e/contract_interaction.cy.ts
@@ -12,7 +12,6 @@ describe("Contract Interaction", () => {
     cy.loadContract("0xca808b3eada02d53073e129b25f74b31d8647ae0");
     cy.url().should("include", "/0xca808b3eada02d53073e129b25f74b31d8647ae0/8453");
     cy.contains("Implementation Address").should("be.visible");
-    cy.wait(1000); // wait for: the method card to re-render
     cy.interactWithMethod("balanceOf", "0xd8dA6BF26964aF9D7eEd9e03E53415D37aA96045");
   });
 
@@ -42,6 +41,8 @@ describe("Contract Interaction", () => {
 
   it("should add Viction as a custom chain and interact with a contract by submitting an ABI manually", () => {
     cy.visit("http://localhost:3000");
+    cy.selectNetwork("Add custom chain");
+    cy.get("#add-custom-chain-modal").should("be.visible");
     cy.addCustomChain({
       id: "88",
       name: "Viction",

--- a/packages/nextjs/cypress/support/commands.ts
+++ b/packages/nextjs/cypress/support/commands.ts
@@ -20,8 +20,12 @@ Cypress.Commands.add("loadContract", (address: string) => {
 });
 
 Cypress.Commands.add("selectNetwork", (networkName: string) => {
-  cy.get("#react-select-container").click();
-  cy.get('[role="option"]').contains(networkName).click();
+  cy.get("#react-select-container")
+    .click()
+    .find("input")
+    .first()
+    .type(networkName, { force: true })
+    .type("{enter}", { force: true });
 });
 
 Cypress.Commands.add("interactWithMethod", (methodName: string, inputValue: string) => {
@@ -42,8 +46,6 @@ Cypress.Commands.add(
     rpcUrl: string;
     blockExplorer: string;
   }) => {
-    cy.get("#react-select-container").click();
-    cy.get('[role="option"]').contains("Add custom chain").click();
     cy.get("#add-custom-chain-modal").should("be.visible");
     cy.get('input[name="id"]').type(chainDetails.id);
     cy.get('input[name="name"]').type(chainDetails.name);


### PR DESCRIPTION
## Description

### This PR:

- Changes the way that the networks are selected from the dropdown:
Instead of clicking on the dropdown and looking for a something with `[role="option"]`, we click on the dropdown menu, start typing the network name, and click on the first result that appears:
`cy.get("#react-select-container")
    .click()
    .find("input")
    .first()
    .type(networkName, { force: true })
    .type("{enter}", { force: true });`
    
- Changes the way Custom chains dropdown entry is selected to the method above
- Removes the 1000 ms delay on the proxy contract on Base test 


I have tested these changes at least 50 times on my local instance but cypress may behave differently on gh actions

## Additional Information

- [x] I have read the [contributing docs](https://github.com/BuidlGuidl/abi.ninja/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/BuidlGuidl/abi.ninja/pulls)

## Related Issues

Fixes #146 

