### PR TITLE
Fix open zeppelin proxy detection

### DIFF
--- a/packages/nextjs/utils/abi-ninja/proxyContracts.ts
+++ b/packages/nextjs/utils/abi-ninja/proxyContracts.ts
@@ -95,9 +95,6 @@ export const detectProxyTarget = async (proxyAddress: Address, client: UsePublic
       slot: OPEN_ZEPPELIN_IMPLEMENTATION_SLOT,
     });
     const resolvedAddress = readAddress(implementationAddr);
-    if (resolvedAddress === "0x" + "0".repeat(40)) {
-      throw new Error("Zero address in OpenZeppelin implementation slot");
-    }
     return resolvedAddress;
   };
 


### PR DESCRIPTION
## Description

This PR adds support for detecting OpenZeppelin proxies by uncommenting and implementing the OpenZeppelin implementation slot detection logic in the `detectProxyTarget` function.

Changes made:
1. Uncommented the `OPEN_ZEPPELIN_IMPLEMENTATION_SLOT` constant.
2. Added a new `detectUsingOpenZeppelinSlot` function to check for OpenZeppelin proxies.
3. Included the new detection method in the primary detection methods array.

## Additional Information

- [x] I have read the [contributing docs](https://github.com/BuidlGuidl/abi.ninja/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [x] This is not a duplicate of any [existing pull request](https://github.com/BuidlGuidl/abi.ninja/pulls)

## Related Issues

Fixes #154 

Your ENS/address: portdev.eth