### PR TITLE
Use ensdata api to reduce api calls

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Address.tsx
+++ b/packages/nextjs/components/scaffold-eth/Address.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { CopyToClipboard } from "react-copy-to-clipboard";
 import { Address as AddressType, isAddress } from "viem";
 import { hardhat } from "viem/chains";
-import { normalize } from "viem/ens";
-import { useEnsAvatar, useEnsName } from "wagmi";
 import { CheckCircleIcon, DocumentDuplicateIcon } from "@heroicons/react/24/outline";
 import { BlockieAvatar } from "~~/components/scaffold-eth";
+import { useEnsData } from "~~/hooks/useEnsData";
 import { useGlobalState } from "~~/services/store/store";
 import { getBlockExplorerAddressLink } from "~~/utils/scaffold-eth";
 
@@ -30,36 +29,9 @@ const blockieSizeMap = {
  * Displays an address (or ENS) with a Blockie image and option to copy address.
  */
 export const Address = ({ address, disableAddressLink, format, size = "base" }: AddressProps) => {
-  const [ens, setEns] = useState<string | null>();
-  const [ensAvatar, setEnsAvatar] = useState<string | null>();
   const [addressCopied, setAddressCopied] = useState(false);
-
   const targetNetwork = useGlobalState(state => state.targetNetwork);
-
-  const { data: fetchedEns } = useEnsName({
-    address: address,
-    chainId: 1,
-    query: {
-      enabled: isAddress(address ?? ""),
-    },
-  });
-  const { data: fetchedEnsAvatar } = useEnsAvatar({
-    name: fetchedEns ? normalize(fetchedEns) : undefined,
-    chainId: 1,
-    query: {
-      enabled: Boolean(fetchedEns),
-      gcTime: 30_000,
-    },
-  });
-
-  // We need to apply this pattern to avoid Hydration errors.
-  useEffect(() => {
-    setEns(fetchedEns);
-  }, [fetchedEns]);
-
-  useEffect(() => {
-    setEnsAvatar(fetchedEnsAvatar);
-  }, [fetchedEnsAvatar]);
+  const { ens, avatar_url } = useEnsData(address ?? "");
 
   // Skeleton UI
   if (!address) {
@@ -91,7 +63,7 @@ export const Address = ({ address, disableAddressLink, format, size = "base" }: 
       <div className="flex-shrink-0">
         <BlockieAvatar
           address={address}
-          ensImage={ensAvatar}
+          ensImage={avatar_url}
           size={(blockieSizeMap[size] * 24) / blockieSizeMap["base"]}
         />
       </div>

--- a/packages/nextjs/hooks/useEnsData.ts
+++ b/packages/nextjs/hooks/useEnsData.ts
@@ -1,0 +1,32 @@
+import { useQuery } from "@tanstack/react-query";
+import { Address as AddressType, isAddress } from "viem";
+
+const isEns = (value: string) => value.endsWith(".eth") || value.endsWith(".xyz");
+
+export const useEnsData = (addressOrEns: AddressType | string) => {
+  const { data: ensData } = useQuery({
+    queryKey: ["ensData", addressOrEns],
+    queryFn: async () => {
+      if (!addressOrEns || (!isAddress(addressOrEns) && !isEns(addressOrEns))) return {};
+
+      const response = await fetch(`https://ensdata.net/${addressOrEns}`);
+      const data = await response.json();
+
+      if (data.error) {
+        return { error: true };
+      }
+
+      return {
+        ens: data.ens,
+        address: data.address,
+        avatar_url: data.avatar_url || data.records_primary.avatar_small,
+      };
+    },
+    staleTime: 24 * 60 * 60 * 1000, // 24 hours
+    gcTime: 7 * 24 * 60 * 60 * 1000, // 7 days
+    enabled: Boolean(addressOrEns) && (isEns(addressOrEns) || isAddress(addressOrEns)),
+    retry: false,
+  });
+
+  return ensData || {};
+};


### PR DESCRIPTION
## Description

### This PR:
-> Creates a new hook `useEnsData` and gets ens avatar, address, and name from ensdata api
-> Changes the way AddressInput works
-> Blocks blo images from appearing unless it is a full address inside the input(maybe we should get this for se-2 as well? maybe we already have it? idk)
-> Blocks blo images from appearing if the address has an ens avatar


We might not use this exact solution there but I think doing too many calls to the ens resolver exists in scaffold eth itself as well
 