### PR TITLE
Show contract creation information in the Contract Overview card

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
@@ -227,26 +227,28 @@ export const ContractUI = ({ className = "", initialContractData }: ContractUIPr
                     </span>
                   </p>
                 )}
-                <div className="my-0 text-sm flex items-center gap-2">
-                  <span className="font-bold">Created at:</span>
-                  {isContractCreationLoading ? (
-                    <span className="loading loading-spinner loading-xs"></span>
-                  ) : (
-                    contractCreationInfo && (
-                      <>
-                        <span>Block {contractCreationInfo.blockNumber}</span>
-                        <a
-                          href={getBlockExplorerTxLink(chainId, contractCreationInfo.txHash)}
-                          target="_blank"
-                          rel="noopener noreferrer"
-                          className="link no-underline"
-                        >
-                          <ArrowTopRightOnSquareIcon className="w-4 h-4" />
-                        </a>
-                      </>
-                    )
-                  )}
-                </div>
+                {!isContractCreationLoading && contractCreationInfo && (
+                  <div className="my-0 text-sm flex items-center gap-2">
+                    <span className="font-bold">Created at:</span>
+                    {isContractCreationLoading ? (
+                      <span className="loading loading-spinner loading-xs"></span>
+                    ) : (
+                      contractCreationInfo && (
+                        <>
+                          <span>Block {contractCreationInfo.blockNumber}</span>
+                          <a
+                            href={getBlockExplorerTxLink(chainId, contractCreationInfo.txHash)}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="link no-underline"
+                          >
+                            <ArrowTopRightOnSquareIcon className="w-4 h-4" />
+                          </a>
+                        </>
+                      )
+                    )}
+                  </div>
+                )}
               </div>
               <div className="bg-base-200 shadow-xl rounded-2xl px-6 py-4">
                 <span className="block font-bold pb-3">Contract Data</span>

--- a/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
@@ -6,6 +6,7 @@ import { ContractWriteMethods } from "./ContractWriteMethods";
 import { AbiFunction } from "abitype";
 import { Abi, Address as AddressType } from "viem";
 import { useContractRead } from "wagmi";
+import { ArrowTopRightOnSquareIcon } from "@heroicons/react/24/outline";
 import { MiniFooter } from "~~/components/MiniFooter";
 import { Address, Balance, MethodSelector } from "~~/components/scaffold-eth";
 import { useNetworkColor } from "~~/hooks/scaffold-eth";
@@ -253,17 +254,18 @@ export const ContractUI = ({ className = "", initialContractData }: ContractUIPr
                   </p>
                 )}
                 {contractCreation && (
-                  <p className="my-0 text-sm">
-                    <span className="font-bold">Contract Creation</span>:{" "}
+                  <div className="my-0 text-sm flex items-center gap-2">
+                    <span className="font-bold">Created at:</span>
+                    <span>Block {contractCreation.blockNumber}</span>
                     <a
                       href={getBlockExplorerTxLink(chainId, contractCreation.txHash)}
                       target="_blank"
                       rel="noopener noreferrer"
                       className="link no-underline"
                     >
-                      Block {contractCreation.blockNumber} ({contractCreation.timestamp})
+                      <ArrowTopRightOnSquareIcon className="w-4 h-4" />
                     </a>
-                  </p>
+                  </div>
                 )}
               </div>
               <div className="bg-base-200 shadow-xl rounded-2xl px-6 py-4">

--- a/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
@@ -10,7 +10,7 @@ import { MiniFooter } from "~~/components/MiniFooter";
 import { Address, Balance, MethodSelector } from "~~/components/scaffold-eth";
 import { useNetworkColor } from "~~/hooks/scaffold-eth";
 import { useGlobalState } from "~~/services/store/store";
-import { getTargetNetworks } from "~~/utils/scaffold-eth";
+import { getBlockExplorerTxLink, getTargetNetworks } from "~~/utils/scaffold-eth";
 
 type ContractUIProps = {
   className?: string;
@@ -56,11 +56,18 @@ const augmentMethodsWithUid = (methods: AbiFunction[]): AugmentedAbiFunction[] =
 
 const mainNetworks = getTargetNetworks();
 
+type ContractCreationInfo = {
+  blockNumber: string;
+  timestamp: string;
+  txHash: string;
+};
+
 /**
  * UI component to interface with deployed contracts.
  **/
 export const ContractUI = ({ className = "", initialContractData }: ContractUIProps) => {
   const [refreshDisplayVariables, triggerRefreshDisplayVariables] = useReducer(value => !value, false);
+  const [contractCreation, setContractCreation] = useState<ContractCreationInfo | null>(null);
   const { implementationAddress, chainId } = useGlobalState(state => ({
     chainId: state.targetNetwork.id,
     implementationAddress: state.implementationAddress,
@@ -138,6 +145,31 @@ export const ContractUI = ({ className = "", initialContractData }: ContractUIPr
     // Default to "Contract" for errors or any other cases
     return "Contract";
   }, [isContractNameLoading, contractNameData]);
+
+  useEffect(() => {
+    const fetchContractCreation = async () => {
+      try {
+        const apiKey = process.env.NEXT_PUBLIC_ETHERSCAN_V2_API_KEY;
+        const response = await fetch(
+          `https://api.etherscan.io/v2/api?chainid=${chainId}&module=contract&action=getcontractcreation&contractaddresses=${initialContractData.address}&apikey=${apiKey}`,
+        );
+        const data = await response.json();
+
+        if (data.status === "1" && data.result && data.result.length > 0) {
+          const creationInfo = data.result[0];
+          setContractCreation({
+            blockNumber: creationInfo.blockNumber,
+            timestamp: new Date(Number(creationInfo.timestamp) * 1000).toLocaleString(),
+            txHash: creationInfo.txHash,
+          });
+        }
+      } catch (error) {
+        console.error("Error fetching contract creation data:", error);
+      }
+    };
+
+    fetchContractCreation();
+  }, [chainId, initialContractData.address]);
 
   return (
     <div className="drawer sm:drawer-open h-full">
@@ -218,6 +250,19 @@ export const ContractUI = ({ className = "", initialContractData }: ContractUIPr
                     <span style={{ color: networkColor }}>
                       {mainNetwork.id == 31337 ? "Localhost" : mainNetwork.name}
                     </span>
+                  </p>
+                )}
+                {contractCreation && (
+                  <p className="my-0 text-sm">
+                    <span className="font-bold">Contract Creation</span>:{" "}
+                    <a
+                      href={getBlockExplorerTxLink(chainId, contractCreation.txHash)}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="link no-underline"
+                    >
+                      Block {contractCreation.blockNumber} ({contractCreation.timestamp})
+                    </a>
                   </p>
                 )}
               </div>

--- a/packages/nextjs/hooks/useFetchContractCreationInfo.ts
+++ b/packages/nextjs/hooks/useFetchContractCreationInfo.ts
@@ -1,0 +1,47 @@
+import { useQuery } from "@tanstack/react-query";
+import { Address } from "viem";
+
+type ContractCreationInfo = {
+  blockNumber: string;
+  txHash: string;
+};
+
+type UseFetchContractCreationInfoParams = {
+  contractAddress: Address;
+  chainId: number;
+};
+
+const useFetchContractCreationInfo = ({ contractAddress, chainId }: UseFetchContractCreationInfoParams) => {
+  const fetchContractCreation = async (): Promise<ContractCreationInfo> => {
+    const apiKey = process.env.NEXT_PUBLIC_ETHERSCAN_V2_API_KEY;
+    const response = await fetch(
+      `https://api.etherscan.io/v2/api?chainid=${chainId}&module=contract&action=getcontractcreation&contractaddresses=${contractAddress}&apikey=${apiKey}`,
+    );
+    const data = await response.json();
+
+    if (data.status !== "1" || !data.result || data.result.length === 0) {
+      throw new Error("Failed to fetch contract creation data");
+    }
+
+    const creationInfo = data.result[0];
+    return {
+      blockNumber: creationInfo.blockNumber,
+      txHash: creationInfo.txHash,
+    };
+  };
+
+  const { data, error, isLoading } = useQuery({
+    queryKey: ["contractCreationInfo", { contractAddress, chainId }],
+    queryFn: fetchContractCreation,
+    enabled: Boolean(contractAddress) && chainId !== 31337,
+    retry: false,
+  });
+
+  return {
+    contractCreationInfo: data,
+    error,
+    isLoading,
+  };
+};
+
+export default useFetchContractCreationInfo;


### PR DESCRIPTION
## Description

This PR adds the ability to view contract creation information and link to the creation transaction on block explorers.
-> Adds contract creation information display in the Contract Overview section
-> Integrates with Etherscan API v2 to fetch contract creation data
-> Adds clickable link to view the contract creation transaction on block explorers
