### PR TITLE
Fix Typo in Comment for ABI State in ContractUI.tsx

### DIFF
--- a/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
+++ b/packages/nextjs/components/scaffold-eth/Contract/ContractUI.tsx
@@ -102,7 +102,7 @@ export const ContractUI = ({ className = "", initialContractData }: ContractUIPr
     );
   }, [initialContractData.abi]);
 
-  // local abi state for for dispalying selected methods
+  // local abi state for for displaying selected methods
   const [abi, setAbi] = useState<AugmentedAbiFunction[]>([]);
 
   const handleMethodSelect = (uid: string) => {


### PR DESCRIPTION
## Description

This pull request corrects a typo in a comment within the `ContractUI.tsx` file. The word `displaying` was previously misspelled as `displaying` in the comment describing the local ABI state for displaying selected methods. No functional code changes were made; this update is for clarity and documentation accuracy only.

Your ENS/address: `leopardracer.eth`
